### PR TITLE
Block breaker grief prevention check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.6.3-BlockBreakerFixes3</version>
+    <version>2.6.4-BlockBreakerFixes4</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/Machines/ElectricBlockBreaker.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Machines/ElectricBlockBreaker.java
@@ -203,7 +203,7 @@ public class ElectricBlockBreaker extends SlimefunItem implements InventoryBlock
             if (toggleOnOff.get(b.getLocation())) {
                 invMenu.replaceExistingItem(4, notOperating);
                 if (!targetBlock.getType().equals(Material.AIR)) {
-                    if (hasPermission(b, targetBlock)  && targetBlock.getType().isBlock() && targetBlock.getType().isSolid() && !isBed(targetBlock) && !isDoor(targetBlock) && !ILLEGAL.contains(targetBlock.getType())) {
+                    if (hasPermission(b, targetBlock) && targetBlock.getType().isBlock() && targetBlock.getType().isSolid() && !isBed(targetBlock) && !isDoor(targetBlock) && !ILLEGAL.contains(targetBlock.getType())) {
                         final BlockPosition pos = new BlockPosition(b);
                         int progress = breakerProgress.getOrDefault(pos, 0);
 


### PR DESCRIPTION
## Changes
- Grief Prevention, block breaker should not destroy a block inside a protected region unless given permission
- Block Breaker will not get destroyed by TNT's or by an android

## Related Issues
TBD

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
