### PR TITLE
Mystery Sticks Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.7.2</version>
+    <version>2.7.3</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
@@ -160,7 +160,7 @@ public class MysteryStickListener implements Listener {
                     ((MysteryStick3) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
-                    blindPlayer(player, level.getLevelReq());
+                    ((MysteryStick3) stickBow).onSwing(e);
                 }
             } else if (stickBow instanceof MysteryStick6) {
                 level.setLevelReq(15);
@@ -171,7 +171,7 @@ public class MysteryStickListener implements Listener {
                     ((MysteryStick6) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
-                    blindPlayer(player, level.getLevelReq());
+                    ((MysteryStick6) stickBow).onSwing(e);
                 }
             } else if (stickBow instanceof MysteryStick9) {
                 level.setLevelReq(20);
@@ -182,7 +182,7 @@ public class MysteryStickListener implements Listener {
                     ((MysteryStick9) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
-                    blindPlayer(player, level.getLevelReq());
+                    ((MysteryStick9) stickBow).onSwing(e);
                 }
             } else {
                 return;
@@ -214,8 +214,6 @@ public class MysteryStickListener implements Listener {
             ((MysteryStick8) stick).onSwing(e);
         } else if (stick instanceof MysteryStick10) {
             ((MysteryStick10) stick).onSwing(e);
-        } else {
-            return;
         }
 
     }
@@ -249,8 +247,6 @@ public class MysteryStickListener implements Listener {
             ((MysteryStick9) stick).LevelChange(event);
         } else if (stick instanceof MysteryStick10) {
             ((MysteryStick10) stick).LevelChange(event);
-        } else {
-            return;
         }
 
     }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
@@ -122,9 +122,10 @@ public class MysteryStick extends SlimefunItem {
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 5");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -143,12 +144,17 @@ public class MysteryStick extends SlimefunItem {
                 }
             }
         }
-
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -178,8 +184,6 @@ public class MysteryStick extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
@@ -129,7 +129,7 @@ public class MysteryStick10 extends SlimefunItem {
             return;
         }
 
-        if(player.getLevel() >= 25)  {
+        if(player.getLevel() >= 25) {
             if(ThreadLocalRandom.current().nextInt(100) < 57) {
                 player.setLevel(player.getLevel() - 8);
             }
@@ -163,9 +163,10 @@ public class MysteryStick10 extends SlimefunItem {
             }
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 25");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -190,7 +191,13 @@ public class MysteryStick10 extends SlimefunItem {
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
-        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_7);
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
+        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_10);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -230,8 +237,6 @@ public class MysteryStick10 extends SlimefunItem {
 
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
@@ -121,9 +121,10 @@ public class MysteryStick2 extends SlimefunItem {
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 5");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -148,6 +149,12 @@ public class MysteryStick2 extends SlimefunItem {
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_2);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -177,8 +184,6 @@ public class MysteryStick2 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -103,6 +105,11 @@ public class MysteryStick3 extends SlimefunItem {
         Arrow arrow = (Arrow) event.getDamager();
         Player player = ((Player) arrow.getShooter());
         ItemStack item = player.getInventory().getItemInMainHand();
+
+        if(item.getType() != Material.BOW) {
+            return;
+        }
+
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
@@ -121,11 +128,24 @@ public class MysteryStick3 extends SlimefunItem {
             }
         }
 
+        if(player.getLevel() <= 5) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
+            player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
+            player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 5");
+            transformWeapon(player, item);
+        }
+
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel() && p.getLevel() > 5) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_3);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -154,8 +174,6 @@ public class MysteryStick3 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
@@ -124,9 +124,10 @@ public class MysteryStick4 extends SlimefunItem {
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 15");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -151,6 +152,12 @@ public class MysteryStick4 extends SlimefunItem {
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_4);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -182,8 +189,6 @@ public class MysteryStick4 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
@@ -123,9 +123,10 @@ public class MysteryStick5 extends SlimefunItem {
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 15");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -144,12 +145,17 @@ public class MysteryStick5 extends SlimefunItem {
                 }
             }
         }
-
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_5);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -180,8 +186,6 @@ public class MysteryStick5 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
@@ -20,6 +20,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
@@ -106,6 +108,11 @@ public class MysteryStick6 extends SlimefunItem {
         Arrow arrow = (Arrow) event.getDamager();
         Player player = ((Player) arrow.getShooter());
         ItemStack item = player.getInventory().getItemInMainHand();
+
+        if(item.getType() != Material.BOW) {
+            return;
+        }
+
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
@@ -124,12 +131,25 @@ public class MysteryStick6 extends SlimefunItem {
             }
         }
 
+        if(player.getLevel() <= 15) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
+            player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
+            player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 15");
+            transformWeapon(player, item);
+        }
+
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
-        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_3);
+        if(event.getOldLevel() > event.getNewLevel() && p.getLevel() > 15) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
+        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_6);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -159,8 +179,6 @@ public class MysteryStick6 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
@@ -146,9 +146,10 @@ public class MysteryStick7 extends SlimefunItem {
             }
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -173,6 +174,12 @@ public class MysteryStick7 extends SlimefunItem {
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_7);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -208,11 +215,8 @@ public class MysteryStick7 extends SlimefunItem {
                     item.setItemMeta(meta);
                     item.setType(item2.getType());
                 }
-
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
@@ -145,9 +145,10 @@ public class MysteryStick8 extends SlimefunItem {
             }
         }
         else{
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 1000, 2, false, false));
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
             player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
+            transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
@@ -172,6 +173,12 @@ public class MysteryStick8 extends SlimefunItem {
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel()) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_8);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -208,8 +215,6 @@ public class MysteryStick8 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick9.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick9.java
@@ -117,6 +117,11 @@ public class MysteryStick9 extends SlimefunItem {
         Arrow arrow = (Arrow) event.getDamager();
         Player player = ((Player) arrow.getShooter());
         ItemStack item = player.getInventory().getItemInMainHand();
+
+        if(item.getType() != Material.BOW) {
+            return;
+        }
+
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
@@ -147,11 +152,24 @@ public class MysteryStick9 extends SlimefunItem {
                 victim.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 1, false, true));
             }
         }
+
+        if(player.getLevel() <= 20) {
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
+            player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
+            player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
+            transformWeapon(player, item);
+        }
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
+        if(event.getOldLevel() > event.getNewLevel() && p.getLevel() > 20) {
+            transformWeapon(p, item);
+        }
+    }
+
+    public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_9);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
@@ -188,8 +206,6 @@ public class MysteryStick9 extends SlimefunItem {
                 }
             }
         }
-
-
     }
 
     @Override


### PR DESCRIPTION
## Changes
- Fixed mystery sticks not transforming back to stick when below the level requirements
- Code chores
- Lessen the time of blindness effect

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
