### PR TITLE
Mystery sticks balancing and new multiblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,15 @@ Addon support 1.15.x, 1.16.x and 1.17.x minecraft version
 ![config2](https://user-images.githubusercontent.com/88238718/142844555-64fb0203-3d3a-4a32-8c22-ca4123fe31c5.png)
 ![config3](https://user-images.githubusercontent.com/88238718/136697386-a52bc1d3-2897-4524-bea4-b64c308065ed.png)
 
-
-Huge thanks to Slimefun for making their work open-source and free to use.
+### Head to my addon channel at SF Addon Community Server for feedbacks 
+<p>
+  <a href="https://discord.gg/slimefun">
+    <img src="https://discordapp.com/api/guilds/565557184348422174/widget.png?style=banner3" alt="Discord Invite"/>
+  </a>
+  <a href="https://discord.gg/SqD3gg5SAU">
+    <img src="https://discordapp.com/api/guilds/809178621424041997/widget.png?style=banner3" alt="Discord Invite"/>
+  </a>
+</p>
 
 Addon is now part of Slimefun Community Addons! Go check out others addon here:
 https://github.com/Slimefun/Slimefun4/wiki/Addons
-
-Discord: FN_FAL113#7779

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ Addon support 1.15.x, 1.16.x and 1.17.x minecraft version
 #### Machinery and Items Category
 ![Machinery Category](https://user-images.githubusercontent.com/88238718/138582199-7b18befb-dfd6-42b7-8962-e538a1535b41.png)![Machinery Items Category](https://user-images.githubusercontent.com/88238718/138582200-9995884a-39a5-406f-9f55-598698e3c767.png)
 
+#### Mystery Sticks Category
+![MysterySticks](https://user-images.githubusercontent.com/88238718/145703147-d8c55904-81d4-4509-9eb6-af84ca038ae4.png)
+
 ## Everything is configurable in terms of Power Rates, Buffer, Capacity, Tick Rates and Lores
 ![config1](https://user-images.githubusercontent.com/88238718/142844553-2b141c58-e0f8-4595-8e29-3099d690fadd.png)
 ![config2](https://user-images.githubusercontent.com/88238718/142844555-64fb0203-3d3a-4a32-8c22-ca4123fe31c5.png)

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
@@ -6,6 +6,7 @@ import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Machines.*;
 import ne.fnfal113.fnamplifications.MaterialGenerators.FNMaterialGenerators;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import ne.fnfal113.fnamplifications.Multiblock.FnScrapRecycler;
 import ne.fnfal113.fnamplifications.MysteriousItems.*;
 import ne.fnfal113.fnamplifications.PowerGenerators.FNSolarGenerators;
@@ -91,6 +92,7 @@ public final class FNAmpItemSetup {
     private void registerMultiBlock() {
         new FnAssemblyStation().register(FNAmplifications.getInstance());
         new FnScrapRecycler().register(FNAmplifications.getInstance());
+        new FnMysteryStickAltar().register(FNAmplifications.getInstance());
     }
 
     private void registerScrapRecipes() {
@@ -112,5 +114,6 @@ public final class FNAmpItemSetup {
         MysteryStick8.setup();
         MysteryStick9.setup();
         MysteryStick10.setup();
+        MysteryStick11.setup();
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -50,7 +50,7 @@ public class FNAmpItems {
             FN_ITEMS,
             new CustomItemStack(PlayerHead.getItemStack(PlayerSkin.fromHashCode(
                     "ecb316f7a227a8c59d58ae0dd6768fe4fa546d55b9cfdd56cfe40b6586d81c24")),
-            "&eFN_FAL's Power Xpansion"));
+            "&eFN_FAL'S Power Xpansion"));
 
     public static final SubItemGroup MATERIAL_GENERATORS = new SubItemGroup(
             new NamespacedKey(FNAmplifications.getInstance(), "MATERIAL_GENERATORS"),
@@ -97,7 +97,7 @@ public class FNAmpItems {
             new NamespacedKey(FNAmplifications.getInstance(), "MYSTERY_STICKS"),
             FN_ITEMS,
             new CustomItemStack(STICK,
-                    "&eMystery Sticks (PVP/PVE)"));
+                    "&eFN_FAL'S Mystery PVP/PVE Sticks"));
 
     public static final ItemGroup FN_AMPLIFICATIONS = new ItemGroup(
             new NamespacedKey(FNAmplifications.getInstance(), "FN_AMPLIFICATIONS"),
@@ -1008,5 +1008,18 @@ public class FNAmpItems {
             Material.STICK,
             "&cMysterious Stick X",
             "&fDeadly or creepy stick"
+    );
+
+    public static final SlimefunItemStack FN_STICK_11 = new SlimefunItemStack(
+            "FN_MYSTERY_STICK_11",
+            Material.STICK,
+            "&cMysterious Stick XI",
+            "&fThe stick of the nords"
+    );
+
+    public static final SlimefunItemStack FN_STICK_ALTAR = new SlimefunItemStack(
+            "FN_STICK_ALTAR",
+            Material.ENCHANTING_TABLE,
+            "&dFN Mystery Stick Altar"
     );
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Multiblock/FnMysteryStickAltar.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Multiblock/FnMysteryStickAltar.java
@@ -1,0 +1,148 @@
+package ne.fnfal113.fnamplifications.Multiblock;
+
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.core.multiblocks.MultiBlockMachine;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.ItemUtils;
+import io.github.thebusybiscuit.slimefun4.libraries.paperlib.PaperLib;
+import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockFace;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Dispenser;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+public class FnMysteryStickAltar extends MultiBlockMachine {
+
+    public static final RecipeType RECIPE_TYPE = new RecipeType(
+            new NamespacedKey(FNAmplifications.getInstance(), "fn_mystery_stick_altar"),
+            FNAmpItems.FN_STICK_ALTAR,
+            "",
+            "&fThis is where you craft the mysterious sticks!"
+    );
+
+
+    public FnMysteryStickAltar() {
+        super(FNAmpItems.MULTIBLOCK, FNAmpItems.FN_STICK_ALTAR, new ItemStack[] {
+                null , null , null,
+                null, new ItemStack(Material.DARK_OAK_FENCE), null,
+                new ItemStack(Material.ENCHANTING_TABLE), new ItemStack(Material.DISPENSER), new ItemStack(Material.ENCHANTING_TABLE)
+        }, BlockFace.SELF);
+    }
+
+    @Override
+    public void onInteract(Player p, Block b) {
+        Block dispBlock = b.getRelative(BlockFace.DOWN);
+        BlockState state = PaperLib.getBlockState(dispBlock, false).getState();
+
+        if (state instanceof Dispenser) {
+            Dispenser disp = (Dispenser) state;
+            Inventory inv = disp.getInventory();
+            List<ItemStack[]> inputs = RecipeType.getRecipeInputList(this);
+
+            for (int i = 0; i < inputs.size(); i++) {
+                if (canCraft(inv, inputs.get(i))) {
+                    ItemStack output = RecipeType.getRecipeOutputList(this, inputs.get(i)).clone();
+
+                    if (SlimefunUtils.canPlayerUseItem(p, output, true)) {
+                        craft(dispBlock, p, b, inv, inputs.get(i), output);
+                    }
+
+                    return;
+                }
+            }
+
+            if (SlimefunUtils.isInventoryEmpty(inv)) {
+                Slimefun.getLocalization().sendMessage(p, "machines.inventory-empty", true);
+            } else {
+                Slimefun.getLocalization().sendMessage(p, "machines.pattern-not-found", true);
+            }
+        }
+    }
+
+    private boolean canCraft(Inventory inv, ItemStack[] recipe) {
+        for (int j = 0; j < inv.getContents().length; j++) {
+            if (!SlimefunUtils.isItemSimilar(inv.getContents()[j], recipe[j], true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    protected void craft(Block dispenser, Player p, Block b, Inventory inv, ItemStack[] recipe, ItemStack output) {
+        Inventory fakeInv = createVirtualInventory(inv);
+        Inventory outputInv = findOutputInventory(output, dispenser, inv, fakeInv);
+
+        if (outputInv != null) {
+            for (int j = 0; j < 9; j++) {
+                ItemStack item = inv.getContents()[j];
+
+                if (item != null && item.getType() != Material.AIR && SlimefunUtils.isItemSimilar(inv.getContents()[j], recipe[j], true)) {
+                    ItemUtils.consumeItem(item, recipe[j].getAmount(),true);
+                }
+            }
+
+            Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
+                    b.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+                    b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.3, 0.4, 0.45), 2, 0.1, 0.1, 0.1, 0.1);
+                    b.getWorld().playSound(b.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1, 1);
+
+                Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
+                    b.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+                    b.getWorld().spawnParticle(Particle.FLASH, b.getLocation().add(0.4, 0.45, 0.5), 2, 0.1, 0.1, 0.1, 0.1);
+                    b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.4, 0.45, 0.5), 2, 0.1, 0.1, 0.1, 0.1);
+                    b.getWorld().playSound(b.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1, 1);
+
+                    Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
+                        b.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+                        b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.2, 0.3, 0.2), 2, 0.1, 0.1, 0.1, 0.1);
+                        b.getWorld().playSound(b.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1, 1);
+
+                        Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
+                            b.getWorld().playEffect(b.getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+                            b.getWorld().spawnParticle(Particle.FLASH, b.getLocation().add(0.35, 0.4, 0.4), 2, 0.1, 0.1, 0.1, 0.1);
+                            b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.35, 0.4, 0.4), 2, 0.1, 0.1, 0.1, 0.1);
+                            b.getWorld().playSound(b.getLocation(), Sound.ENTITY_ENDERMAN_TELEPORT, 1, 1);
+
+
+                            outputInv.addItem(output);
+                            p.sendMessage(ChatColor.DARK_PURPLE + "" + ChatColor.BOLD + "Mystery Stick is now ready to use!");
+                        }, 30);
+                    }, 30);
+                }, 30);
+            }, 30);
+        } else {
+            Slimefun.getLocalization().sendMessage(p, "machines.full-inventory", true);
+            p.sendMessage(ChatColor.YELLOW + "" + ChatColor.BOLD + "Add an output chest for the outputs!");
+        }
+    }
+
+    protected @Nonnull
+    Inventory createVirtualInventory(@Nonnull Inventory inv) {
+        Inventory fakeInv = Bukkit.createInventory(null, 9, "Fake Inventory");
+
+        for (int j = 0; j < inv.getContents().length; j++) {
+            ItemStack stack = inv.getContents()[j];
+
+            if (stack != null) {
+                stack = stack.clone();
+                ItemUtils.consumeItem(stack, true);
+            }
+
+            fakeInv.setItem(j, stack);
+        }
+
+        return fakeInv;
+    }
+
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
@@ -127,6 +127,15 @@ public class MysteryStickListener implements Listener {
             }
         }
 
+        if(stick instanceof MysteryStick11 && (e.getAction() == Action.RIGHT_CLICK_BLOCK || e.getAction() == Action.RIGHT_CLICK_AIR)){
+            click.setLevelReq(25);
+            if(p.getLevel() >= click.getLevelReq()  && checkStick(stick)) {
+                ((MysteryStick11) stick).interact(e);
+            } else {
+                blindPlayer(p, click.getLevelReq());
+            }
+        }
+
     }
 
     public boolean checkStick(SlimefunItem stick){
@@ -154,8 +163,8 @@ public class MysteryStickListener implements Listener {
             if(stickBow instanceof MysteryStick3) {
                 level.setLevelReq(5);
                 if (player.getLevel() >= level.getLevelReq()) {
-                    if (ThreadLocalRandom.current().nextInt(100) < 35) {
-                        player.setLevel(player.getLevel() - 3);
+                    if (ThreadLocalRandom.current().nextInt(100) < 20) {
+                        player.setLevel(player.getLevel() - 1);
                     }
                     ((MysteryStick3) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
@@ -165,8 +174,8 @@ public class MysteryStickListener implements Listener {
             } else if (stickBow instanceof MysteryStick6) {
                 level.setLevelReq(15);
                 if (player.getLevel() >= level.getLevelReq()) {
-                    if (ThreadLocalRandom.current().nextInt(100) < 50) {
-                        player.setLevel(player.getLevel() - 5);
+                    if (ThreadLocalRandom.current().nextInt(100) < 25) {
+                        player.setLevel(player.getLevel() - 2);
                     }
                     ((MysteryStick6) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
@@ -176,8 +185,8 @@ public class MysteryStickListener implements Listener {
             } else if (stickBow instanceof MysteryStick9) {
                 level.setLevelReq(20);
                 if (player.getLevel() >= level.getLevelReq()) {
-                    if (ThreadLocalRandom.current().nextInt(100) < 55) {
-                        player.setLevel(player.getLevel() - 6);
+                    if (ThreadLocalRandom.current().nextInt(100) < 30) {
+                        player.setLevel(player.getLevel() - 3);
                     }
                     ((MysteryStick9) stickBow).onSwing(e);
                     player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
@@ -214,6 +223,8 @@ public class MysteryStickListener implements Listener {
             ((MysteryStick8) stick).onSwing(e);
         } else if (stick instanceof MysteryStick10) {
             ((MysteryStick10) stick).onSwing(e);
+        } else if (stick instanceof MysteryStick11) {
+            ((MysteryStick11) stick).onSwing(e);
         }
 
     }
@@ -247,6 +258,8 @@ public class MysteryStickListener implements Listener {
             ((MysteryStick9) stick).LevelChange(event);
         } else if (stick instanceof MysteryStick10) {
             ((MysteryStick10) stick).LevelChange(event);
+        } else if (stick instanceof MysteryStick11) {
+            ((MysteryStick11) stick).LevelChange(event);
         }
 
     }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -65,9 +66,9 @@ public class MysteryStick extends SlimefunItem {
         lore.add(ChatColor.GOLD + "What is this sorcery?");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 5, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 6, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 4, true);
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 3, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 4, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 2, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -116,7 +117,7 @@ public class MysteryStick extends SlimefunItem {
         }
 
         if(player.getLevel() >= 5)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 35) {
+            if(ThreadLocalRandom.current().nextInt(100) < 20) {
                 player.setLevel(player.getLevel() - 1);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
@@ -202,10 +203,10 @@ public class MysteryStick extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.MAGIC_LUMP_1, SlimefunItems.ENDER_LUMP_1, SlimefunItems.ENDER_LUMP_1,
+        new MysteryStick(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 2), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 2),
                 SlimefunItems.BLANK_RUNE, new ItemStack(Material.STICK), SlimefunItems.BLANK_RUNE,
-                SlimefunItems.MAGIC_LUMP_1, SlimefunItems.MAGIC_LUMP_1, SlimefunItems.ENDER_LUMP_1})
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 4), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 2)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.enchantments.Enchantment;
@@ -71,12 +72,12 @@ public class MysteryStick10 extends SlimefunItem {
         lore.add(ChatColor.BLUE +"◆ 40% Chance 5s Poison");
         lore.add(ChatColor.BLUE +"◆ 35% Chance 5s Wither");
         lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Weakness");
-        lore.add(ChatColor.BLUE +"◆ 25% Chance ♡♡ Lifesteal");
+        lore.add(ChatColor.BLUE +"◆ 25% Chance ♡ Lifesteal");
         lore.add(ChatColor.BLUE +"◆ 20% Chance 180° rotation");
         lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 22, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 27, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 22, true);
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 20, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 22, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 15, true);
         meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 17, true);
         meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 17, true);
         meta.setLore(lore);
@@ -130,8 +131,8 @@ public class MysteryStick10 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 25) {
-            if(ThreadLocalRandom.current().nextInt(100) < 57) {
-                player.setLevel(player.getLevel() - 8);
+            if(ThreadLocalRandom.current().nextInt(100) < 35) {
+                player.setLevel(player.getLevel() - 4);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
@@ -150,6 +151,8 @@ public class MysteryStick10 extends SlimefunItem {
                     int playerDefaultHealth = (int) player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getDefaultValue();
                     if(player.getHealth() < playerDefaultHealth - 2)  {
                         player.setHealth(player.getHealth() + 2);
+                    } else {
+                        player.sendMessage(ChatColor.RED + "Make sure your hp points is below 18 for Lifesteal to proc!");
                     }
                 }
                 if(ThreadLocalRandom.current().nextInt(100) < 20){
@@ -202,7 +205,7 @@ public class MysteryStick10 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 7;
+        int amount = ++xpamount + 3;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -255,10 +258,10 @@ public class MysteryStick10 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick10(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_10, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.ESSENCE_OF_AFTERLIFE, FNAmpItems.FN_STICK_4, SlimefunItems.ENCHANTMENT_RUNE,
-                SlimefunItems.FIRE_RUNE, FNAmpItems.FN_STICK_7, SlimefunItems.AIR_RUNE,
-                SlimefunItems.LIGHTNING_RUNE, FNAmpItems.FN_STICK,SlimefunItems.ESSENCE_OF_AFTERLIFE})
+        new MysteryStick10(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_10, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 32), FNAmpItems.FN_STICK_4, new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 28),
+                new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 28), FNAmpItems.FN_STICK_7, new SlimefunItemStack(SlimefunItems.AIR_RUNE, 28),
+                new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 28), FNAmpItems.FN_STICK, new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 32)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick11.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick11.java
@@ -12,7 +12,6 @@ import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.entity.Arrow;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -33,7 +32,7 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import static org.bukkit.ChatColor.stripColor;
 
-public class MysteryStick9 extends SlimefunItem {
+public class MysteryStick11 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
 
@@ -41,11 +40,11 @@ public class MysteryStick9 extends SlimefunItem {
     private final NamespacedKey defaultUsageKey2;
 
     @ParametersAreNonnullByDefault
-    public MysteryStick9(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public MysteryStick11(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
-        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "bowexp_xpfinal");
-        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "bowdamage_damagefinal");
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "axeexp_xpfinalfn");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "axeexpdamage_damagefinalfn");
     }
 
     protected @Nonnull
@@ -64,19 +63,19 @@ public class MysteryStick9 extends SlimefunItem {
 
         ItemMeta meta = item1.getItemMeta();
         ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "I wonder if Elves possess this relic");
+        lore.add(ChatColor.GOLD + "Behind your enemies awaits danger");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
         lore.add("");
         lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 35% Chance 3s Levitation");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Harm");
-        lore.add(ChatColor.BLUE +"◆ 20% Chance 3s Blindness");
+        lore.add(ChatColor.BLUE +"◆ 35% Chance 5s Slow");
+        lore.add(ChatColor.BLUE +"◆ 40% Chance 4s Weakness");
+        lore.add(ChatColor.BLUE +"◆ 30% Chance 5s Hunger");
+        lore.add(ChatColor.BLUE +"◆ 25% Chance tp behind opponent");
         lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 15, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 12, true);
-        meta.addEnchant(Enchantment.ARROW_FIRE, 12, true);
-        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 14, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 20, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 18, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 18, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -104,8 +103,8 @@ public class MysteryStick9 extends SlimefunItem {
             }
         }
 
-        if(!(item1.getType() == Material.BOW)) {
-            item1.setType(Material.BOW);
+        if(!(item1.getType() == Material.DIAMOND_AXE)) {
+            item1.setType(Material.DIAMOND_AXE);
             player.playSound(player.getLocation(), Sound.ENTITY_ILLUSIONER_MIRROR_MOVE, 1, 1);
             player.getWorld().playEffect(player.getLocation().add(0.3, 0.4, 0.45), Effect.ENDER_SIGNAL, 1);
             player.getWorld().spawnParticle(Particle.FLASH, player.getLocation().add(0.3, 0.4, 0.45), 2, 0.1, 0.1, 0.1, 0.1);
@@ -114,15 +113,59 @@ public class MysteryStick9 extends SlimefunItem {
 
     }
 
+
     public void onSwing(EntityDamageByEntityEvent event){
-        Arrow arrow = (Arrow) event.getDamager();
-        Player player = ((Player) arrow.getShooter());
+        if(!(event.getDamager() instanceof Player)){
+            return;
+        }
+        Player player = (Player) event.getDamager();
         ItemStack item = player.getInventory().getItemInMainHand();
 
-        if(item.getType() != Material.BOW) {
+        if(item.getType() != Material.DIAMOND_AXE){
             return;
         }
 
+        if(player.getLevel() >= 25)  {
+            if(ThreadLocalRandom.current().nextInt(100) < 35) {
+                player.setLevel(player.getLevel() - 4);
+            }
+            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
+            if(event.getEntity() instanceof LivingEntity) {
+                LivingEntity victim = (LivingEntity) event.getEntity();
+                if(ThreadLocalRandom.current().nextInt(100) < 35){
+                    victim.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 100, 1, false, true));
+                }
+                if(ThreadLocalRandom.current().nextInt(100) < 40){
+                    victim.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 80, 1, false, true));
+                }
+                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                    victim.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 100, 1, false, true));
+                }
+                if(ThreadLocalRandom.current().nextInt(100) < 25){
+                    double nX;
+                    double nZ;
+                    float nang = victim.getLocation().getYaw() + 90;
+
+                    if(nang < 0) nang += 360;
+
+                    nX = Math.cos(Math.toRadians(nang));
+                    nZ = Math.sin(Math.toRadians(nang));
+
+                    Location newDamagerLoc = new Location(player.getWorld(), victim.getLocation().getX() - nX,
+                            victim.getLocation().getY(), victim.getLocation().getZ() - nZ, victim.getLocation().getYaw(), victim.getLocation().getPitch());
+                    player.teleport(newDamagerLoc);
+                    victim.sendMessage(ChatColor.RED + "" + ChatColor.BOLD + "Behind you awaits danger");
+                }
+            } else {
+                return;
+            }
+        }
+        else{
+            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
+            player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
+            player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 25");
+            transformWeapon(player, item);
+        }
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
@@ -141,42 +184,23 @@ public class MysteryStick9 extends SlimefunItem {
             }
         }
 
-        if(event.getEntity() instanceof LivingEntity) {
-            LivingEntity victim = (LivingEntity) event.getEntity();
-            if(ThreadLocalRandom.current().nextInt(100) < 35){
-                victim.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, 60, 1, false, true));
-            }
-            if(ThreadLocalRandom.current().nextInt(100) < 30){
-                victim.addPotionEffect(new PotionEffect(PotionEffectType.HARM, 80, 1, false, true));
-            }
-            if(ThreadLocalRandom.current().nextInt(100) < 20){
-                victim.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 1, false, true));
-            }
-        }
-
-        if(player.getLevel() <= 20) {
-            player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
-            player.sendTitle(ChatColor.DARK_RED + "Your vision darkens!", ChatColor.RED + "The stick is unpredictable", 45, 120, 135);
-            player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
-            transformWeapon(player, item);
-        }
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
-        if(event.getOldLevel() > event.getNewLevel() && p.getLevel() > 20) {
+        if(event.getOldLevel() > event.getNewLevel()) {
             transformWeapon(p, item);
         }
     }
 
     public void transformWeapon(Player p, ItemStack item) {
-        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_9);
+        CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_11);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 2;
+        int amount = ++xpamount + 3;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -188,20 +212,20 @@ public class MysteryStick9 extends SlimefunItem {
                     meta.setLore(lore);
                     item.setItemMeta(meta);
                 }
-                if (stripColor(line).startsWith("I wonder if Elves possess this relic") && p.getLevel() <= 20) {
+                if (stripColor(line).startsWith("Behind your enemies awaits danger") && p.getLevel() <= 25) {
                     lore.remove(3);
                     lore.remove(3);
                     lore.remove(3);
                     lore.remove(3);
                     lore.remove(3);
                     lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "You need more mana when using this");
+                    lore.remove(3);
+                    lore.set(index, ChatColor.WHITE + "The stick of the nords");
                     lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
                     meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.ARROW_DAMAGE);
-                    meta.removeEnchant(Enchantment.ARROW_INFINITE);
-                    meta.removeEnchant(Enchantment.ARROW_FIRE);
-                    meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
+                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
+                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
                     item.setItemMeta(meta);
                     item.setType(item2.getType());
                 }
@@ -225,10 +249,10 @@ public class MysteryStick9 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick9(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_9, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
-                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 28), SlimefunItems.AIR_RUNE, new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 28),
-                new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 20), FNAmpItems.FN_STICK_6, new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 20),
-                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 28), new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 20), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 28)})
+        new MysteryStick11(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_11, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                FNAmpItems.FN_STICK_2, SlimefunItems.ESSENCE_OF_AFTERLIFE, FNAmpItems.FN_STICK_8,
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 32), FNAmpItems.FN_STICK_5, new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 32),
+                new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 32), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 32), new SlimefunItemStack(SlimefunItems.AIR_RUNE, 32)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -64,9 +65,9 @@ public class MysteryStick2 extends SlimefunItem {
         lore.add(ChatColor.GOLD + "Another stick of wrecking");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 5, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 4, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 6, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 3, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 2, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 3, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -115,8 +116,8 @@ public class MysteryStick2 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 5)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 35) {
-                player.setLevel(player.getLevel() - 2);
+            if(ThreadLocalRandom.current().nextInt(100) < 20) {
+                player.setLevel(player.getLevel() - 1);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
@@ -160,7 +161,7 @@ public class MysteryStick2 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 1;
+        int amount = ++xpamount;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -202,10 +203,10 @@ public class MysteryStick2 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick2(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_2, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.MAGIC_LUMP_1, new ItemStack(Material.LEATHER), SlimefunItems.ENDER_LUMP_1,
+        new MysteryStick2(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_2, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 5), new ItemStack(Material.LEATHER), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 4),
                 SlimefunItems.BLANK_RUNE, new ItemStack(Material.STICK), SlimefunItems.BLANK_RUNE,
-                SlimefunItems.ENDER_LUMP_1, new ItemStack(Material.LEATHER), SlimefunItems.MAGIC_LUMP_1})
+                new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 4), new ItemStack(Material.LEATHER), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_1, 5)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Arrow;
@@ -64,8 +65,8 @@ public class MysteryStick3 extends SlimefunItem {
         lore.add(ChatColor.GOLD + "I knew it was something about shooting arrows");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 7, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 5, true);
+        meta.addEnchant(Enchantment.ARROW_DAMAGE, 3, true);
+        meta.addEnchant(Enchantment.ARROW_INFINITE, 4, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -151,7 +152,7 @@ public class MysteryStick3 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 2;
+        int amount = ++xpamount;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -192,10 +193,10 @@ public class MysteryStick3 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick3(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_3, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.BLANK_RUNE, new ItemStack(Material.LEATHER), SlimefunItems.BLANK_RUNE,
-                SlimefunItems.MAGIC_LUMP_2, new ItemStack(Material.STICK), SlimefunItems.MAGIC_LUMP_2,
-                SlimefunItems.ENDER_LUMP_1, new ItemStack(Material.LEAD), SlimefunItems.ENDER_LUMP_1})
+        new MysteryStick3(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_3, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 3), new ItemStack(Material.LEATHER), new SlimefunItemStack(SlimefunItems.BLANK_RUNE, 3),
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_2, 8), new ItemStack(Material.STICK), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_2, 8),
+                new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 6), new ItemStack(Material.LEAD), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_1, 6)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -64,11 +65,11 @@ public class MysteryStick4 extends SlimefunItem {
         lore.add(ChatColor.GOLD + "It was indeed a magical improvement");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 20, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 10, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 10, true);
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 7, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 8, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 5, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 6, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -118,8 +119,8 @@ public class MysteryStick4 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 15)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 50) {
-                player.setLevel(player.getLevel() - 5);
+            if(ThreadLocalRandom.current().nextInt(100) < 25) {
+                player.setLevel(player.getLevel() - 2);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
@@ -163,7 +164,7 @@ public class MysteryStick4 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 4;
+        int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -207,10 +208,10 @@ public class MysteryStick4 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick4(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_4, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.EARTH_RUNE, SlimefunItems.ENDER_LUMP_3,
-                SlimefunItems.FIRE_RUNE, FNAmpItems.FN_STICK, SlimefunItems.AIR_RUNE,
-                SlimefunItems.ENDER_LUMP_3, SlimefunItems.ENDER_RUNE,SlimefunItems.ESSENCE_OF_AFTERLIFE})
+        new MysteryStick4(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_4, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4), new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 4), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 12),
+                new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 4), FNAmpItems.FN_STICK, new SlimefunItemStack(SlimefunItems.AIR_RUNE, 4),
+                new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 12), new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 4), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
@@ -64,10 +65,10 @@ public class MysteryStick5 extends SlimefunItem {
         lore.add(ChatColor.GOLD + "Another stick of somewhat reckoning");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 15, true);
-        meta.addEnchant(Enchantment.KNOCKBACK, 10, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 5, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 5, true);
+        meta.addEnchant(Enchantment.KNOCKBACK, 4, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -117,8 +118,8 @@ public class MysteryStick5 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 15)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 50) {
-                player.setLevel(player.getLevel() - 5);
+            if(ThreadLocalRandom.current().nextInt(100) < 25) {
+                player.setLevel(player.getLevel() - 2);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
@@ -161,7 +162,7 @@ public class MysteryStick5 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 4;
+        int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -204,10 +205,10 @@ public class MysteryStick5 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick5(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_5, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.MAGIC_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.ENDER_LUMP_2,
-                SlimefunItems.AIR_RUNE, FNAmpItems.FN_STICK_2, SlimefunItems.FIRE_RUNE,
-                SlimefunItems.ENDER_LUMP_3, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.MAGIC_LUMP_2})
+        new MysteryStick5(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_5, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 14), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_2, 16),
+                new SlimefunItemStack(SlimefunItems.AIR_RUNE, 6), FNAmpItems.FN_STICK_2, new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 6),
+                new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 16), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_2, 14)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Arrow;
@@ -64,10 +65,10 @@ public class MysteryStick6 extends SlimefunItem {
         lore.add(ChatColor.GOLD + "Make them take an arrow to the knee");
         lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
         lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 20, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 10, true);
-        meta.addEnchant(Enchantment.ARROW_FIRE, 10, true);
-        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 10, true);
+        meta.addEnchant(Enchantment.ARROW_DAMAGE, 7, true);
+        meta.addEnchant(Enchantment.ARROW_INFINITE, 5, true);
+        meta.addEnchant(Enchantment.ARROW_FIRE, 6, true);
+        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 7, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -154,7 +155,7 @@ public class MysteryStick6 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 4;
+        int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -197,10 +198,10 @@ public class MysteryStick6 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick6(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_6, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.AIR_RUNE, SlimefunItems.ESSENCE_OF_AFTERLIFE,
-                SlimefunItems.FIRE_RUNE, FNAmpItems.FN_STICK_3, SlimefunItems.EARTH_RUNE,
-                SlimefunItems.ENDER_LUMP_3, SlimefunItems.ENDER_RUNE, SlimefunItems.MAGIC_LUMP_3})
+        new MysteryStick6(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_6, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4), new SlimefunItemStack(SlimefunItems.AIR_RUNE, 6), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 4),
+                new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 6), FNAmpItems.FN_STICK_3, new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 6),
+                new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 24), new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 6), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 24)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
@@ -71,11 +72,11 @@ public class MysteryStick7 extends SlimefunItem {
         lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Wither");
         lore.add(ChatColor.BLUE +"◆ 25% Chance 4s Weakness");
         lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 25, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 15, true);
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 17, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 10, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 13, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -126,8 +127,8 @@ public class MysteryStick7 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 20)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 55) {
-                player.setLevel(player.getLevel() - 6);
+            if(ThreadLocalRandom.current().nextInt(100) < 30) {
+                player.setLevel(player.getLevel() - 3);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
@@ -185,7 +186,7 @@ public class MysteryStick7 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 5;
+        int amount = ++xpamount + 2;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -235,10 +236,10 @@ public class MysteryStick7 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick7(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_7, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.EARTH_RUNE, SlimefunItems.ENCHANTMENT_RUNE,
-                SlimefunItems.FIRE_RUNE, FNAmpItems.FN_STICK_4, SlimefunItems.AIR_RUNE,
-                SlimefunItems.LIGHTNING_RUNE, SlimefunItems.ENDER_RUNE,SlimefunItems.ESSENCE_OF_AFTERLIFE})
+        new MysteryStick7(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_7, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 16), new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 16),  new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 16),
+                new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 16), FNAmpItems.FN_STICK_4, new SlimefunItemStack(SlimefunItems.AIR_RUNE, 16),
+                new SlimefunItemStack(SlimefunItems.LIGHTNING_RUNE, 16), new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 16), new SlimefunItemStack(SlimefunItems.ENCHANTMENT_RUNE, 16)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
@@ -9,6 +9,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.LivingEntity;
@@ -71,10 +72,10 @@ public class MysteryStick8 extends SlimefunItem {
         lore.add(ChatColor.BLUE +"◆ 30% Chance 3s Weakness");
         lore.add(ChatColor.BLUE +"◆ 25% Chance 4s Hunger");
         lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 25, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 20, true);
-        meta.addEnchant(Enchantment.KNOCKBACK, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 13, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
+        meta.addEnchant(Enchantment.KNOCKBACK, 10, true);
         meta.setLore(lore);
         meta.setUnbreakable(true);
         item1.setItemMeta(meta);
@@ -125,8 +126,8 @@ public class MysteryStick8 extends SlimefunItem {
         }
 
         if(player.getLevel() >= 20)  {
-            if(ThreadLocalRandom.current().nextInt(100) < 55) {
-                player.setLevel(player.getLevel() - 6);
+            if(ThreadLocalRandom.current().nextInt(100) < 30) {
+                player.setLevel(player.getLevel() - 3);
             }
             event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
@@ -184,7 +185,7 @@ public class MysteryStick8 extends SlimefunItem {
         NamespacedKey key = getStorageKey();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
-        int amount = ++xpamount + 5;
+        int amount = ++xpamount + 2;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
         List<String> lore = meta.getLore();
 
@@ -233,10 +234,10 @@ public class MysteryStick8 extends SlimefunItem {
     }
 
     public static void setup(){
-        new MysteryStick8(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_8, RecipeType.MAGIC_WORKBENCH, new ItemStack[]{
-                SlimefunItems.ENDER_RUNE, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.FIRE_RUNE,
-                SlimefunItems.ESSENCE_OF_AFTERLIFE, FNAmpItems.FN_STICK_5, SlimefunItems.ESSENCE_OF_AFTERLIFE,
-                SlimefunItems.EARTH_RUNE, SlimefunItems.ESSENCE_OF_AFTERLIFE, SlimefunItems.AIR_RUNE})
+        new MysteryStick8(FNAmpItems.MYSTERY_STICKS, FNAmpItems.FN_STICK_8, FnMysteryStickAltar.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.ENDER_RUNE, 18), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 20), new SlimefunItemStack(SlimefunItems.FIRE_RUNE, 18),
+                new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 20), FNAmpItems.FN_STICK_5, new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 20),
+                new SlimefunItemStack(SlimefunItems.EARTH_RUNE, 18), new SlimefunItemStack(SlimefunItems.ESSENCE_OF_AFTERLIFE, 20), new SlimefunItemStack(SlimefunItems.AIR_RUNE, 18)})
                 .register(plugin);
     }
 }


### PR DESCRIPTION
## Changes
- Re-balanced mystery sticks enchantment levels and exp level chance to consume for every use
- Adjusted the recipes for all the sticks (made it more harder and fun)
- Added a new multiblock where the sticks can be crafted (FN Mystery Stick Altar)
- Added Mysterious Stick XI (this gives you another bonus effect/ability)

## Related Issues

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
