### PR TITLE
FN Gears of Friction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.7.4</version>
+    <version>2.7.5</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
@@ -5,16 +5,12 @@ import javax.annotation.Nonnull;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.GitHubBuildsUpdater;
 
-import ne.fnfal113.fnamplifications.ConfigUpdater.ConfigUpdater;
+import ne.fnfal113.fnamplifications.Gears.Listeners.GearListener;
 import ne.fnfal113.fnamplifications.MysteriousItems.Listeners.MysteryStickListener;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import ne.fnfal113.fnamplifications.Items.FNAmpItemSetup;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
 
 public final class FNAmplifications extends JavaPlugin implements SlimefunAddon {
 
@@ -36,22 +32,10 @@ public final class FNAmplifications extends JavaPlugin implements SlimefunAddon 
         FNAmpItemSetup.INSTANCE.init();
 
         getServer().getPluginManager().registerEvents(new MysteryStickListener(), this);
+        getServer().getPluginManager().registerEvents(new GearListener(), this);
 
         getConfig().options().copyDefaults();
         saveDefaultConfig();
-
-        //The config needs to exist before using the updater
-        File configFile = new File(getDataFolder(), "config.yml");
-
-        if(configFile.exists()) {
-            try {
-                ConfigUpdater.update(FNAmplifications.instance, "config.yml", configFile, Arrays.asList());
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-
-            reloadConfig();
-        }
 
         if (getConfig().getBoolean("auto-update", true) && getDescription().getVersion().startsWith("DEV - ")) {
             new GitHubBuildsUpdater(this, getFile(), "FN-FAL113/FN-FAL-s-Amplifications/main").start();

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
@@ -1,0 +1,369 @@
+package ne.fnfal113.fnamplifications.Gears;
+
+import com.google.common.base.Strings;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.bukkit.ChatColor.stripColor;
+
+public class FnBoots extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+    private final NamespacedKey defaultUsageKey3;
+
+
+    @ParametersAreNonnullByDefault
+    public FnBoots(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "boots");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "bootslevel");
+        this.defaultUsageKey3 = new NamespacedKey(FNAmplifications.getInstance(), "boostfinal");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey3() {
+        return defaultUsageKey3;
+    }
+
+
+    public void onHit(EntityDamageByEntityEvent event){
+        if(!(event.getEntity() instanceof Player)){
+            return;
+        }
+
+        Player p = ((Player) event.getEntity()).getPlayer();
+        ItemStack itemStack = p.getInventory().getBoots();
+
+        ItemMeta meta = itemStack.getItemMeta();
+
+        if (meta == null) {
+            return;
+        }
+
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        NamespacedKey key3 = getStorageKey3();
+        PersistentDataContainer progress = meta.getPersistentDataContainer();
+        PersistentDataContainer level = meta.getPersistentDataContainer();
+        PersistentDataContainer max = meta.getPersistentDataContainer();
+        int amount = progress.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int armorLevel = level.getOrDefault(key2, PersistentDataType.INTEGER, 0);
+        int maxReq = max.getOrDefault(key3, PersistentDataType.INTEGER, 25);
+        int total = amount + 1;
+        progress.set(key, PersistentDataType.INTEGER, total);
+
+        List<String> lore = new ArrayList<>();
+
+        if (total >= 0) {
+            lore.add(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(1, "");
+            lore.add(2, ChatColor.WHITE + "Soldiers from FN's army only wants to posses");
+            lore.add(3, ChatColor.WHITE + "this historical boots but it was kept");
+            lore.add(4, ChatColor.WHITE + "hidden under the hands of the zion people");
+            lore.add(5, "");
+            lore.add(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(7, ChatColor.YELLOW + "Boots Level: " + armorLevel);
+            lore.add(8, ChatColor.YELLOW + "Progress:");
+            lore.add(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+
+        if (total == maxReq) {
+            progress.set(key, PersistentDataType.INTEGER, 0);
+            int totalLevel = armorLevel + 1;
+            level.set(key2, PersistentDataType.INTEGER, totalLevel);
+            lore.set(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(1, "");
+            lore.set(2, ChatColor.WHITE + "Soldiers from FN's army only wants to posses");
+            lore.set(3, ChatColor.WHITE + "this historical boots but it was kept");
+            lore.set(4, ChatColor.WHITE + "hidden under the hands of the zion people");
+            lore.set(5, "");
+            lore.set(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(7, ChatColor.YELLOW + "Boots Level: " + totalLevel);
+            lore.set(8, ChatColor.YELLOW + "Progress:");
+            lore.set(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            max.set(key3, PersistentDataType.INTEGER, maxReq + 100);
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+            upgradeArmor(itemStack, totalLevel, p);
+        }
+
+
+    }
+
+    public void upgradeArmor(ItemStack armor, int level, Player p){
+        ItemMeta meta = armor.getItemMeta();
+
+        if(meta == null){
+            return;
+        }
+
+        if(level == 1){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 2){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 3){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 4){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 5){
+            meta.addEnchant(Enchantment.DEPTH_STRIDER, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 4.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 3.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 6){
+            meta.addEnchant(Enchantment.FROST_WALKER, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 7){
+            meta.addEnchant(Enchantment.PROTECTION_FALL, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 8){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 9){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 10){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 6, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 4.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Boots attributes has been increased!");
+        } else if(level == 11){
+            meta.addEnchant(Enchantment.THORNS, 5, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 12){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 13){
+            meta.addEnchant(Enchantment.DEPTH_STRIDER, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 14){
+            meta.addEnchant(Enchantment.PROTECTION_FALL, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 15){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 10, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 4.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Boots attributes has been increased!");
+        } else if(level == 16){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 12, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 17){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 18){
+            meta.addEnchant(Enchantment.THORNS, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 19){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 20){
+            meta.addEnchant(Enchantment.DEPTH_STRIDER, 12, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_MOVEMENT_SPEED, new AttributeModifier(UUID.randomUUID(), "generic.movementSpeed.helmet", 0.06, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Boots attributes has been increased!");
+        } else if (level == 21){
+            meta.addEnchant(Enchantment.PROTECTION_FALL, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 22){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 23){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 24){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 25){
+            meta.addEnchant(Enchantment.THORNS, 16, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_MOVEMENT_SPEED, new AttributeModifier(UUID.randomUUID(), "generic.movementSpeed.helmet", 0.07, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Boots attributes has been increased!");
+        } else if (level == 26){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 27){
+            meta.addEnchant(Enchantment.DEPTH_STRIDER, 14, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 28){
+            meta.addEnchant(Enchantment.PROTECTION_FALL, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 29){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 30){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 20, true);
+            meta.removeAttributeModifier(EquipmentSlot.FEET);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.4, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            meta.addAttributeModifier(Attribute.GENERIC_MOVEMENT_SPEED, new AttributeModifier(UUID.randomUUID(), "generic.movementSpeed.helmet", 0.08, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.FEET));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Boots attributes has been increased!");
+        } else if (level == 31){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 32){
+            meta.addEnchant(Enchantment.THORNS, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 33){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 34){
+            meta.addEnchant(Enchantment.DEPTH_STRIDER, 18, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 35){
+            meta.addEnchant(Enchantment.PROTECTION_FALL, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level > 35){
+            levelUp(p);
+        }
+
+    }
+
+    public void levelUp(Player p){
+        p.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications]> " + ChatColor.GOLD + "FN's Expedition Combat Boots leveled up!");
+        p.playSound(p.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1 , 1);
+    }
+
+    public String getProgressBar(int current, int max, int totalBars, char symbol, ChatColor completedColor,
+                                 ChatColor notCompletedColor) {
+        float percent = (float) current / max;
+        int progressBars = (int) (totalBars * percent);
+
+        return Strings.repeat("" + completedColor + symbol, progressBars)
+                + Strings.repeat("" + notCompletedColor + symbol, totalBars - progressBars);
+    }
+
+    @Override
+    public boolean isEnchantable() {
+        return true;
+    }
+
+    @Override
+    public boolean isDisenchantable() {
+        return false;
+    }
+
+    @Override
+    public boolean isUseableInWorkbench() {
+        return false;
+    }
+
+    public static void setup(){
+        new FnBoots(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_BOOTS, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 5), new ItemStack(Material.IRON_BOOTS), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 5),
+                SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 6), SlimefunItems.ENCHANTMENT_RUNE,
+                new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6), new ItemStack(Material.DIAMOND_BOOTS), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6)})
+                .register(plugin);
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnChestPlate.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnChestPlate.java
@@ -1,0 +1,320 @@
+package ne.fnfal113.fnamplifications.Gears;
+
+import com.google.common.base.Strings;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.bukkit.ChatColor.stripColor;
+
+public class FnChestPlate extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+    private final NamespacedKey defaultUsageKey3;
+
+
+    @ParametersAreNonnullByDefault
+    public FnChestPlate(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "armor");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "armorlevel");
+        this.defaultUsageKey3 = new NamespacedKey(FNAmplifications.getInstance(), "armorfinal");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey3() {
+        return defaultUsageKey3;
+    }
+
+
+    public void onHit(EntityDamageByEntityEvent event){
+        if(!(event.getEntity() instanceof Player)){
+            return;
+        }
+
+        Player p = ((Player) event.getEntity()).getPlayer();
+        ItemStack itemStack = p.getInventory().getChestplate();
+
+        ItemMeta meta = itemStack.getItemMeta();
+
+        if (meta == null) {
+            return;
+        }
+
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        NamespacedKey key3 = getStorageKey3();
+        PersistentDataContainer progress = meta.getPersistentDataContainer();
+        PersistentDataContainer level = meta.getPersistentDataContainer();
+        PersistentDataContainer max = meta.getPersistentDataContainer();
+        int amount = progress.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int armorLevel = level.getOrDefault(key2, PersistentDataType.INTEGER, 0);
+        int maxReq = max.getOrDefault(key3, PersistentDataType.INTEGER, 30);
+        int total = amount + 1;
+        progress.set(key, PersistentDataType.INTEGER, total);
+
+        List<String> lore = new ArrayList<>();;
+
+        if (total >= 0) {
+            lore.add(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(1, "");
+            lore.add(2, ChatColor.WHITE + "The armor from the past brought to life");
+            lore.add(3, ChatColor.WHITE + "once again. It becomes more powerful during");
+            lore.add(4, ChatColor.WHITE + "times of war and conflict");
+            lore.add(5, "");
+            lore.add(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(7, ChatColor.YELLOW + "Armor Level: " + armorLevel);
+            lore.add(8, ChatColor.YELLOW + "Progress:");
+            lore.add(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+
+        if (total == maxReq) {
+            progress.set(key, PersistentDataType.INTEGER, 0);
+            int totalLevel = armorLevel + 1;
+            level.set(key2, PersistentDataType.INTEGER, totalLevel);
+            lore.set(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(1, "");
+            lore.set(2, ChatColor.WHITE + "The armor from the past brought to life");
+            lore.set(3, ChatColor.WHITE + "once again. It becomes more powerful during");
+            lore.set(4, ChatColor.WHITE + "times of war and conflict");
+            lore.set(5, "");
+            lore.set(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(7, ChatColor.YELLOW + "Armor Level: " + totalLevel);
+            lore.set(8, ChatColor.YELLOW + "Progress:");
+            lore.set(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            max.set(key3, PersistentDataType.INTEGER, maxReq + 120);
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+            upgradeArmor(itemStack, totalLevel, p);
+        }
+
+
+    }
+
+
+    public void upgradeArmor(ItemStack armor, int level, Player p){
+        ItemMeta meta = armor.getItemMeta();
+
+        if(meta == null){
+            return;
+        }
+
+        if(level == 1){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 2){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 3){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 4){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 5){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.CHEST);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.chest", 3.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.chest", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Chestplate attributes has been increased!");
+        } else if(level == 6){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 7){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 8){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 9){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 10){
+            meta.addEnchant(Enchantment.THORNS, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.CHEST);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.chest", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.chest", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Chestplate attributes has been increased!");
+        } else if(level == 11){
+            meta.addEnchant(Enchantment.THORNS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 12){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 13){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 14){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 15){
+            meta.addEnchant(Enchantment.THORNS, 10, true);
+            meta.removeAttributeModifier(EquipmentSlot.CHEST);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.chest", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.chest", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Chestplate attributes has been increased!");
+        } else if(level == 16){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 17){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 14, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 18){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 16, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 19){
+            meta.addEnchant(Enchantment.THORNS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 20){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 15, true);
+            meta.removeAttributeModifier(EquipmentSlot.CHEST);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.chest", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.chest", 0.4, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Chestplate attributes has been increased!");
+        } else if (level == 21){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 22){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 23){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 24){
+            meta.addEnchant(Enchantment.THORNS, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 25){
+            meta.addEnchant(Enchantment.THORNS, 20, true);
+            meta.removeAttributeModifier(EquipmentSlot.CHEST);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 12.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.chest", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.chest", 0.4, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Chestplate attributes has been increased!");
+        } else if (level > 25){
+            levelUp(p);
+        }
+
+    }
+
+    public void levelUp(Player p){
+        p.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications]> " + ChatColor.GOLD + "FN's Battle Scarred Chestplate leveled up!");
+        p.playSound(p.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1 , 1);
+    }
+
+    public String getProgressBar(int current, int max, int totalBars, char symbol, ChatColor completedColor,
+                                 ChatColor notCompletedColor) {
+        float percent = (float) current / max;
+        int progressBars = (int) (totalBars * percent);
+
+        return Strings.repeat("" + completedColor + symbol, progressBars)
+                + Strings.repeat("" + notCompletedColor + symbol, totalBars - progressBars);
+    }
+
+    @Override
+    public boolean isEnchantable() {
+        return true;
+    }
+
+    @Override
+    public boolean isDisenchantable() {
+        return false;
+    }
+
+    @Override
+    public boolean isUseableInWorkbench() {
+        return false;
+    }
+
+    public static void setup(){
+        new FnChestPlate(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_CHESTPLATE, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2), new ItemStack(Material.IRON_CHESTPLATE), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2),
+                SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 4), SlimefunItems.ENCHANTMENT_RUNE,
+                new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 4), new ItemStack(Material.DIAMOND_CHESTPLATE), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 4)})
+                .register(plugin);
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnHelmet.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnHelmet.java
@@ -1,0 +1,347 @@
+package ne.fnfal113.fnamplifications.Gears;
+
+import com.google.common.base.Strings;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.bukkit.ChatColor.stripColor;
+
+public class FnHelmet extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+    private final NamespacedKey defaultUsageKey3;
+
+
+    @ParametersAreNonnullByDefault
+    public FnHelmet(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "helmet");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "helmetlevel");
+        this.defaultUsageKey3 = new NamespacedKey(FNAmplifications.getInstance(), "helmetfinal");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey3() {
+        return defaultUsageKey3;
+    }
+
+
+    public void onHit(EntityDamageByEntityEvent event){
+        if(!(event.getEntity() instanceof Player)){
+            return;
+        }
+
+
+        Player p = ((Player) event.getEntity()).getPlayer();
+        ItemStack itemStack = p.getInventory().getHelmet();
+
+        ItemMeta meta = itemStack.getItemMeta();
+
+        if (meta == null) {
+            return;
+        }
+
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        NamespacedKey key3 = getStorageKey3();
+        PersistentDataContainer progress = meta.getPersistentDataContainer();
+        PersistentDataContainer level = meta.getPersistentDataContainer();
+        PersistentDataContainer max = meta.getPersistentDataContainer();
+        int amount = progress.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int armorLevel = level.getOrDefault(key2, PersistentDataType.INTEGER, 0);
+        int maxReq = max.getOrDefault(key3, PersistentDataType.INTEGER, 20);
+        int total = amount + 1;
+        progress.set(key, PersistentDataType.INTEGER, total);
+
+        List<String> lore = new ArrayList<>();
+
+        if (total >= 0) {
+            lore.add(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(1, "");
+            lore.add(2, ChatColor.WHITE + "Wear this helmet in the name of FN and");
+            lore.add(3, ChatColor.WHITE + "every battle should make it become more");
+            lore.add(4, ChatColor.WHITE + "stronger with bonus attributes and enchants");
+            lore.add(5, "");
+            lore.add(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(7, ChatColor.YELLOW + "Helmet Level: " + armorLevel);
+            lore.add(8, ChatColor.YELLOW + "Progress:");
+            lore.add(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+
+        if (total == maxReq) {
+            progress.set(key, PersistentDataType.INTEGER, 0);
+            int totalLevel = armorLevel + 1;
+            level.set(key2, PersistentDataType.INTEGER, totalLevel);
+            lore.set(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(1, "");
+            lore.set(2, ChatColor.WHITE + "Wear this helmet in the name of FN and");
+            lore.set(3, ChatColor.WHITE + "every battle should make it become more");
+            lore.set(4, ChatColor.WHITE + "stronger with bonus attributes and enchants");
+            lore.set(5, "");
+            lore.set(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(7, ChatColor.YELLOW + "Helmet Level: " + totalLevel);
+            lore.set(8, ChatColor.YELLOW + "Progress:");
+            lore.set(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            max.set(key3, PersistentDataType.INTEGER, maxReq + 100);
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+            upgradeArmor(itemStack, totalLevel, p);
+        }
+
+    }
+
+    public void upgradeArmor(ItemStack armor, int level, Player p){
+        ItemMeta meta = armor.getItemMeta();
+
+        if(meta == null){
+            return;
+        }
+
+        if(level == 1){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 2){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 3){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 4){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 5){
+            meta.addEnchant(Enchantment.WATER_WORKER, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 3.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if(level == 6){
+            meta.addEnchant(Enchantment.OXYGEN, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 7){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 8){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 9){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 10){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 6, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if(level == 11){
+            meta.addEnchant(Enchantment.THORNS, 5, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 12){
+            meta.addEnchant(Enchantment.WATER_WORKER, 7, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 13){
+            meta.addEnchant(Enchantment.OXYGEN, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 14){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 15){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 12, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if(level == 16){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 17){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 12, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 18){
+            meta.addEnchant(Enchantment.THORNS, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 19){
+            meta.addEnchant(Enchantment.WATER_WORKER, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if(level == 20){
+            meta.addEnchant(Enchantment.OXYGEN, 12, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.4, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if (level == 21){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 16, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 22){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 23){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 24){
+            meta.addEnchant(Enchantment.THORNS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 25){
+            meta.addEnchant(Enchantment.WATER_WORKER, 16, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.5, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if (level == 26){
+            meta.addEnchant(Enchantment.OXYGEN, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 27){
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 28){
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 22, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 29){
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 30){
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 20, true);
+            meta.removeAttributeModifier(EquipmentSlot.HEAD);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.helmet", 8.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.helmet", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.helmet", 0.5, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.HEAD));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Helmet attributes has been increased!");
+        } else if (level > 30){
+            levelUp(p);
+        }
+
+    }
+
+    public void levelUp(Player p){
+        p.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications]> " + ChatColor.GOLD + "FN's Field Tested Helmet leveled up!");
+        p.playSound(p.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1 , 1);
+    }
+
+    public String getProgressBar(int current, int max, int totalBars, char symbol, ChatColor completedColor,
+                                 ChatColor notCompletedColor) {
+        float percent = (float) current / max;
+        int progressBars = (int) (totalBars * percent);
+
+        return Strings.repeat("" + completedColor + symbol, progressBars)
+                + Strings.repeat("" + notCompletedColor + symbol, totalBars - progressBars);
+    }
+
+    @Override
+    public boolean isEnchantable() {
+        return true;
+    }
+
+    @Override
+    public boolean isDisenchantable() {
+        return false;
+    }
+
+    @Override
+    public boolean isUseableInWorkbench() {
+        return false;
+    }
+
+    public static void setup(){
+        new FnHelmet(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_HELMET, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 4), new ItemStack(Material.IRON_HELMET), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 4),
+                SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 5), SlimefunItems.ENCHANTMENT_RUNE,
+                new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6), new ItemStack(Material.DIAMOND_HELMET), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6)})
+                .register(plugin);
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnLeggings.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnLeggings.java
@@ -1,0 +1,319 @@
+package ne.fnfal113.fnamplifications.Gears;
+
+import com.google.common.base.Strings;
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Sound;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.bukkit.ChatColor.stripColor;
+
+public class FnLeggings extends SlimefunItem{
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+    private final NamespacedKey defaultUsageKey3;
+
+
+    @ParametersAreNonnullByDefault
+    public FnLeggings(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "leggings");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "leggingslevel");
+        this.defaultUsageKey3 = new NamespacedKey(FNAmplifications.getInstance(), "leggingsfinal");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey3() {
+        return defaultUsageKey3;
+    }
+
+
+    public void onHit(EntityDamageByEntityEvent event) {
+        if (!(event.getEntity() instanceof Player)) {
+            return;
+        }
+
+        Player p = ((Player) event.getEntity()).getPlayer();
+        ItemStack itemStack = p.getInventory().getLeggings();
+
+        ItemMeta meta = itemStack.getItemMeta();
+
+        if (meta == null) {
+            return;
+        }
+
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        NamespacedKey key3 = getStorageKey3();
+        PersistentDataContainer progress = meta.getPersistentDataContainer();
+        PersistentDataContainer level = meta.getPersistentDataContainer();
+        PersistentDataContainer max = meta.getPersistentDataContainer();
+        int amount = progress.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int armorLevel = level.getOrDefault(key2, PersistentDataType.INTEGER, 0);
+        int maxReq = max.getOrDefault(key3, PersistentDataType.INTEGER, 30);
+        int total = amount + 1;
+        progress.set(key, PersistentDataType.INTEGER, total);
+
+        List<String> lore = new ArrayList<>();
+
+        if (total >= 0) {
+            lore.add(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(1, "");
+            lore.add(2, ChatColor.WHITE + "Glorious leggings worn by FN during war");
+            lore.add(3, ChatColor.WHITE + "and was glorified on every victory against");
+            lore.add(4, ChatColor.WHITE + "his foes");
+            lore.add(5, "");
+            lore.add(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.add(7, ChatColor.YELLOW + "Leggings Level: " + armorLevel);
+            lore.add(8, ChatColor.YELLOW + "Progress:");
+            lore.add(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+        }
+
+        if (total == maxReq) {
+            progress.set(key, PersistentDataType.INTEGER, 0);
+            int totalLevel = armorLevel + 1;
+            level.set(key2, PersistentDataType.INTEGER, totalLevel);
+            lore.set(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Lore " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(1, "");
+            lore.set(2, ChatColor.WHITE + "Glorious leggings worn by FN during war");
+            lore.set(3, ChatColor.WHITE + "and was glorified on every victory against");
+            lore.set(4, ChatColor.WHITE + "his foes");
+            lore.set(5, "");
+            lore.set(6, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
+                    + ChatColor.BOLD + "Stats " + ChatColor.GOLD + "|◬◬◬◬◬◬");
+            lore.set(7, ChatColor.YELLOW + "Leggings Level: " + totalLevel);
+            lore.set(8, ChatColor.YELLOW + "Progress:");
+            lore.set(9, ChatColor.GRAY + "[" + getProgressBar(total, maxReq, 10, '■', ChatColor.YELLOW, ChatColor.GRAY) + ChatColor.GRAY + "]");
+            max.set(key3, PersistentDataType.INTEGER, maxReq + 105);
+            meta.setLore(lore);
+            itemStack.setItemMeta(meta);
+            upgradeArmor(itemStack, totalLevel, p);
+        }
+
+    }
+
+    public void upgradeArmor(ItemStack armor, int level, Player p) {
+        ItemMeta meta = armor.getItemMeta();
+
+        if (meta == null) {
+            return;
+        }
+
+        if (level == 1) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 2) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 3) {
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 4) {
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 5) {
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.LEGS);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.leggings", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.leggings", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.leggings", 0.1, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Leggings attributes has been increased!");
+        } else if (level == 6) {
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 7) {
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 3, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 8) {
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 9) {
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 10) {
+            meta.addEnchant(Enchantment.THORNS, 3, true);
+            meta.removeAttributeModifier(EquipmentSlot.LEGS);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.leggings", 6.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.leggings", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.leggings", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Leggings attributes has been increased!");
+        } else if (level == 11) {
+            meta.addEnchant(Enchantment.THORNS, 6, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 12) {
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 13) {
+            meta.addEnchant(Enchantment.THORNS, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 14) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 10, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 15) {
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 10, true);
+            meta.removeAttributeModifier(EquipmentSlot.LEGS);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.leggings", 8.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.leggings", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.leggings", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Leggings attributes has been increased!");
+        } else if (level == 16) {
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 17) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 14, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 18) {
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 16, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 19) {
+            meta.addEnchant(Enchantment.THORNS, 15, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 20) {
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 15, true);
+            meta.removeAttributeModifier(EquipmentSlot.LEGS);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.leggings", 8.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.leggings", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.leggings", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Leggings attributes has been increased!");
+        } else if (level == 21) {
+            meta.addEnchant(Enchantment.THORNS, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 22) {
+            meta.addEnchant(Enchantment.PROTECTION_PROJECTILE, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 23) {
+            meta.addEnchant(Enchantment.PROTECTION_ENVIRONMENTAL, 20, true);
+            armor.setItemMeta(meta);
+            levelUp(p);
+        } else if (level == 24) {
+            meta.addEnchant(Enchantment.PROTECTION_EXPLOSIONS, 20, true);
+            levelUp(p);
+        } else if (level == 25) {
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 20, true);
+            meta.removeAttributeModifier(EquipmentSlot.LEGS);
+            armor.setItemMeta(meta);
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.leggings", 10.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_ARMOR_TOUGHNESS, new AttributeModifier(UUID.randomUUID(), "generic.armorTough.leggings", 5.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            meta.addAttributeModifier(Attribute.GENERIC_KNOCKBACK_RESISTANCE, new AttributeModifier(UUID.randomUUID(), "generic.knockbackResistance.leggings", 0.3, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.LEGS));
+            armor.setItemMeta(meta);
+            levelUp(p);
+            p.sendMessage(ChatColor.GOLD + "Leggings attributes has been increased!");
+        } else if (level > 25){
+            levelUp(p);
+        }
+
+
+    }
+
+    public void levelUp(Player p) {
+        p.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications]> " + ChatColor.GOLD + "FN's Chausses of Eminence leveled up!");
+        p.playSound(p.getLocation(), Sound.UI_TOAST_CHALLENGE_COMPLETE, 1, 1);
+    }
+
+    public String getProgressBar(int current, int max, int totalBars, char symbol, ChatColor completedColor,
+                                 ChatColor notCompletedColor) {
+        float percent = (float) current / max;
+        int progressBars = (int) (totalBars * percent);
+
+        return Strings.repeat("" + completedColor + symbol, progressBars)
+                + Strings.repeat("" + notCompletedColor + symbol, totalBars - progressBars);
+    }
+
+    @Override
+    public boolean isEnchantable() {
+        return true;
+    }
+
+    @Override
+    public boolean isDisenchantable() {
+        return false;
+    }
+
+    @Override
+    public boolean isUseableInWorkbench() {
+        return false;
+    }
+
+    public static void setup() {
+        new FnLeggings(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_LEGGINGS, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2), new ItemStack(Material.IRON_LEGGINGS), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2),
+                SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 3), SlimefunItems.ENCHANTMENT_RUNE,
+                new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 3), new ItemStack(Material.DIAMOND_LEGGINGS), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 3)})
+                .register(plugin);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/Listeners/GearListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/Listeners/GearListener.java
@@ -1,0 +1,125 @@
+package ne.fnfal113.fnamplifications.Gears.Listeners;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import ne.fnfal113.fnamplifications.Gears.FnBoots;
+import ne.fnfal113.fnamplifications.Gears.FnChestPlate;
+import ne.fnfal113.fnamplifications.Gears.FnHelmet;
+import ne.fnfal113.fnamplifications.Gears.FnLeggings;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class GearListener implements Listener {
+
+    @EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+    public void progressListener(EntityDamageByEntityEvent event){
+
+        if(event.getDamager() instanceof Arrow){
+
+            Arrow arrow = (Arrow) event.getDamager();
+
+            if (!(arrow.getShooter() instanceof LivingEntity)) {
+                return;
+            }
+
+            if(!(event.getEntity() instanceof Player)) {
+                return;
+            }
+
+            Player p = (Player) event.getEntity();
+
+            if(ThreadLocalRandom.current().nextInt(100) < 55) {
+                SlimefunItem armor = SlimefunItem.getByItem(p.getInventory().getChestplate());
+                if(armor != null) {
+                    if (armor instanceof FnChestPlate) {
+                        ((FnChestPlate) armor).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 50) {
+                SlimefunItem leggings = SlimefunItem.getByItem(p.getInventory().getLeggings());
+                if (leggings != null) {
+                    if (leggings instanceof FnLeggings) {
+                        ((FnLeggings) leggings).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 65) {
+                SlimefunItem helmet = SlimefunItem.getByItem(p.getInventory().getHelmet());
+                if (helmet != null) {
+                    if (helmet instanceof FnHelmet) {
+                        ((FnHelmet) helmet).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 65) {
+                SlimefunItem boots = SlimefunItem.getByItem(p.getInventory().getBoots());
+                if (boots != null) {
+                    if (boots instanceof FnBoots) {
+                        ((FnBoots) boots).onHit(event);
+                    }
+                }
+            }
+
+        }
+
+        if(event.getDamager() instanceof LivingEntity) {
+
+            if(!(event.getEntity() instanceof Player)) {
+                return;
+            }
+
+            Player p = (Player) event.getEntity();
+
+            if(ThreadLocalRandom.current().nextInt(100) < 55) {
+                SlimefunItem armor = SlimefunItem.getByItem(p.getInventory().getChestplate());
+                if(armor != null) {
+                    if (armor instanceof FnChestPlate) {
+                            ((FnChestPlate) armor).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 50) {
+                SlimefunItem leggings = SlimefunItem.getByItem(p.getInventory().getLeggings());
+                if (leggings != null) {
+                    if (leggings instanceof FnLeggings) {
+                        ((FnLeggings) leggings).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 65) {
+                SlimefunItem helmet = SlimefunItem.getByItem(p.getInventory().getHelmet());
+                if (helmet != null) {
+                    if (helmet instanceof FnHelmet) {
+                        ((FnHelmet) helmet).onHit(event);
+                    }
+                }
+            }
+
+            if(ThreadLocalRandom.current().nextInt(100) < 65) {
+                SlimefunItem boots = SlimefunItem.getByItem(p.getInventory().getBoots());
+                if (boots != null) {
+                    if (boots instanceof FnBoots) {
+                        ((FnBoots) boots).onHit(event);
+                    }
+                }
+            }
+
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
@@ -3,6 +3,10 @@ package ne.fnfal113.fnamplifications.Items;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 
 import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Gears.FnBoots;
+import ne.fnfal113.fnamplifications.Gears.FnChestPlate;
+import ne.fnfal113.fnamplifications.Gears.FnHelmet;
+import ne.fnfal113.fnamplifications.Gears.FnLeggings;
 import ne.fnfal113.fnamplifications.Machines.*;
 import ne.fnfal113.fnamplifications.MaterialGenerators.FNMaterialGenerators;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -40,6 +44,7 @@ public final class FNAmpItemSetup {
         registerScrapRecipes();
         registerBlockBreaker();
         registerStick();
+        registerGear();
     }
 
     private void registerPowerGens() {
@@ -115,5 +120,12 @@ public final class FNAmpItemSetup {
         MysteryStick9.setup();
         MysteryStick10.setup();
         MysteryStick11.setup();
+    }
+
+    private void registerGear(){
+        FnChestPlate.setup();
+        FnLeggings.setup();
+        FnHelmet.setup();
+        FnBoots.setup();
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -1,5 +1,6 @@
 package ne.fnfal113.fnamplifications.Items;
 
+import org.bukkit.ChatColor;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 
@@ -32,11 +33,18 @@ public class FNAmpItems {
 
     private static final ItemStack STICK = new ItemStack(Material.STICK);
 
+    private static final ItemStack ARMOR = new ItemStack(Material.NETHERITE_CHESTPLATE);
+
     static{
         ItemMeta meta = STICK.getItemMeta();
         meta.addEnchant(Enchantment.BINDING_CURSE, 1, false);
         meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
         STICK.setItemMeta(meta);
+
+        ItemMeta armorMeta = ARMOR.getItemMeta();
+        armorMeta.addEnchant(Enchantment.BINDING_CURSE, 1, false);
+        armorMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        ARMOR.setItemMeta(armorMeta);
     }
 
     public static final NestedItemGroup FN_ITEMS = new NestedItemGroup(
@@ -98,6 +106,12 @@ public class FNAmpItems {
             FN_ITEMS,
             new CustomItemStack(STICK,
                     "&eFN_FAL'S Mystery PVP/PVE Sticks"));
+
+    public static final SubItemGroup FN_GEARS = new SubItemGroup(
+            new NamespacedKey(FNAmplifications.getInstance(), "FN_GEARS"),
+            FN_ITEMS,
+            new CustomItemStack(ARMOR,
+                    "&eFN_FAL'S Gears of Friction"));
 
     public static final ItemGroup FN_AMPLIFICATIONS = new ItemGroup(
             new NamespacedKey(FNAmplifications.getInstance(), "FN_AMPLIFICATIONS"),
@@ -1021,5 +1035,73 @@ public class FNAmpItems {
             "FN_STICK_ALTAR",
             Material.ENCHANTING_TABLE,
             "&dFN Mystery Stick Altar"
+    );
+
+    public static final SlimefunItemStack FN_GEAR_HELMET = new SlimefunItemStack(
+            "FN_GEAR_HELMET",
+            Material.NETHERITE_HELMET,
+            "&cFN's Field Tested Helmet",
+            "&c◬◬◬◬◬◬| &d&lLore &6|◬◬◬◬◬◬",
+            "",
+            "&fWear this helmet in the name of FN and",
+            "&fevery battle should make it become more",
+            "&fstronger with bonus attributes and enchants",
+            "",
+            "&c◈◈◈◈◈◈| &d&lStats &6|◈◈◈◈◈◈",
+            ChatColor.YELLOW + "Helmet Level: 0",
+            ChatColor.YELLOW + "Progress:",
+            ChatColor.GRAY + "[" + "■■■■■■■■■■" + ChatColor.GRAY + "]"
+
+    );
+
+    public static final SlimefunItemStack FN_GEAR_CHESTPLATE = new SlimefunItemStack(
+            "FN_GEAR_CHESTPLATE",
+            Material.NETHERITE_CHESTPLATE,
+            "&cFN's Battle Scarred Chestplate",
+            "&c◬◬◬◬◬◬| &d&lLore &6|◬◬◬◬◬◬",
+            "",
+            "&fThe armor from the past brought to life",
+            "&fonce again. It becomes more powerful during",
+            "&ftimes of war and conflict",
+            "",
+            "&c◈◈◈◈◈◈| &d&lStats &6|◈◈◈◈◈◈",
+            ChatColor.YELLOW + "Armor Level: 0",
+            ChatColor.YELLOW + "Progress:",
+            ChatColor.GRAY + "[" + "■■■■■■■■■■" + ChatColor.GRAY + "]"
+
+    );
+
+    public static final SlimefunItemStack FN_GEAR_LEGGINGS = new SlimefunItemStack(
+            "FN_GEAR_LEGGINGS",
+            Material.NETHERITE_LEGGINGS,
+            "&cFN's Chausses of Eminence",
+            "&c◬◬◬◬◬◬| &d&lLore &6|◬◬◬◬◬◬",
+            "",
+            "&fGlorious leggings worn by FN during war",
+            "&fand was glorified on every victory against",
+            "&fhis foes",
+            "",
+            "&c◈◈◈◈◈◈| &d&lStats &6|◈◈◈◈◈◈",
+            ChatColor.YELLOW + "Leggings Level: 0",
+            ChatColor.YELLOW + "Progress:",
+            ChatColor.GRAY + "[" + "■■■■■■■■■■" + ChatColor.GRAY + "]"
+
+    );
+
+    public static final SlimefunItemStack FN_GEAR_BOOTS = new SlimefunItemStack(
+            "FN_GEAR_BOOTS",
+            Material.NETHERITE_BOOTS,
+            "&cFN's Expedition Combat Boots",
+            "&c◬◬◬◬◬◬| &d&lLore &6|◬◬◬◬◬◬",
+            "",
+            "&fSoldiers from FN's army only wants to posses",
+            "&fthis historical boots but it was kept",
+            "&fhidden under the hands of the zion people",
+            "",
+            "&c◈◈◈◈◈◈| &d&lStats &6|◈◈◈◈◈◈",
+            ChatColor.YELLOW + "Boots Level: 0",
+            ChatColor.YELLOW + "Progress:",
+            ChatColor.GRAY + "[" + "■■■■■■■■■■" + ChatColor.GRAY + "]"
+
     );
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Machines/ElectricMachineDowngrader.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Machines/ElectricMachineDowngrader.java
@@ -74,7 +74,7 @@ public class ElectricMachineDowngrader extends CMachine implements RecipeDisplay
                     inv.replaceExistingItem(22, new CustomItemStack(Material.BLACK_STAINED_GLASS_PANE, " "));
 
                     for (ItemStack output : currentOperation.getResults()) {
-                        if (ThreadLocalRandom.current().nextInt(100) < 33) {
+                        if (ThreadLocalRandom.current().nextInt(100) < 20) {
                             inv.pushItem(output.clone(), getOutputSlots());
                             inv.pushItem(new CustomItemStack(FNAmpItems.FN_METAL_SCRAPS.clone(), 3), getOutputSlots());
                         }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/Listeners/MysteryStickListener.java
@@ -167,7 +167,6 @@ public class MysteryStickListener implements Listener {
                         player.setLevel(player.getLevel() - 1);
                     }
                     ((MysteryStick3) stickBow).onSwing(e);
-                    player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
                     ((MysteryStick3) stickBow).onSwing(e);
                 }
@@ -178,7 +177,6 @@ public class MysteryStickListener implements Listener {
                         player.setLevel(player.getLevel() - 2);
                     }
                     ((MysteryStick6) stickBow).onSwing(e);
-                    player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
                     ((MysteryStick6) stickBow).onSwing(e);
                 }
@@ -189,7 +187,6 @@ public class MysteryStickListener implements Listener {
                         player.setLevel(player.getLevel() - 3);
                     }
                     ((MysteryStick9) stickBow).onSwing(e);
-                    player.getWorld().playEffect(e.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
                 } else {
                     ((MysteryStick9) stickBow).onSwing(e);
                 }

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick.java
@@ -24,15 +24,11 @@ import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 
-
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
-
-import static org.bukkit.ChatColor.stripColor;
-
 
 public class MysteryStick extends SlimefunItem {
 
@@ -62,16 +58,6 @@ public class MysteryStick extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "What is this sorcery?");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 3, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 4, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 2, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -79,22 +65,13 @@ public class MysteryStick extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 3, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 4, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 2, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_SWORD)) {
             item1.setType(Material.DIAMOND_SWORD);
@@ -120,7 +97,6 @@ public class MysteryStick extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 20) {
                 player.setLevel(player.getLevel() - 1);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -129,22 +105,26 @@ public class MysteryStick extends SlimefunItem {
             transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
+
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "What is this sorcery?");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -159,32 +139,30 @@ public class MysteryStick extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("What is this sorcery?") && p.getLevel() <= 5) {
-                    lore.set(index, ChatColor.WHITE + "I wonder what this stick does");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.SWEEPING_EDGE);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.FIRE_ASPECT);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 5) {
+            lore.set(0, ChatColor.WHITE + "I wonder what this stick does");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.SWEEPING_EDGE);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.FIRE_ASPECT);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick10.java
@@ -31,8 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick10 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -63,26 +61,6 @@ public class MysteryStick10 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Why is this stick too good");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        lore.add("");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 40% Chance 5s Poison");
-        lore.add(ChatColor.BLUE +"◆ 35% Chance 5s Wither");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Weakness");
-        lore.add(ChatColor.BLUE +"◆ 25% Chance ♡ Lifesteal");
-        lore.add(ChatColor.BLUE +"◆ 20% Chance 180° rotation");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 22, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 17, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 17, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -90,22 +68,15 @@ public class MysteryStick10 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 20, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 22, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 17, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 17, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_SWORD)) {
             item1.setType(Material.DIAMOND_SWORD);
@@ -134,23 +105,22 @@ public class MysteryStick10 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 35) {
                 player.setLevel(player.getLevel() - 4);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
                 LivingEntity victim = (LivingEntity) event.getEntity();
-                if(ThreadLocalRandom.current().nextInt(100) < 40){
+                if(ThreadLocalRandom.current().nextInt(100) < 40 && !(victim.hasPotionEffect(PotionEffectType.POISON))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 100, 3, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 35){
+                if(ThreadLocalRandom.current().nextInt(100) < 35 && !(victim.hasPotionEffect(PotionEffectType.WITHER))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 100, 3, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.WEAKNESS))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 80, 3, false, true));
                 }
                 if(ThreadLocalRandom.current().nextInt(100) < 25){
-                    victim.setHealth(victim.getHealth() - 2);
                     int playerDefaultHealth = (int) player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getDefaultValue();
                     if(player.getHealth() < playerDefaultHealth - 2)  {
                         player.setHealth(player.getHealth() + 2);
+                        victim.setHealth(victim.getHealth() - 2);
                     } else {
                         player.sendMessage(ChatColor.RED + "Make sure your hp points is below 18 for Lifesteal to proc!");
                     }
@@ -171,24 +141,36 @@ public class MysteryStick10 extends SlimefunItem {
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 25");
             transformWeapon(player, item);
         }
+
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Why is this stick too good");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        lore2.add(3, "");
+        lore2.add(4, ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        lore2.add(5, ChatColor.BLUE +"◆ 40% Chance 5s Poison");
+        lore2.add(6, ChatColor.BLUE +"◆ 35% Chance 5s Wither");
+        lore2.add(7, ChatColor.BLUE +"◆ 30% Chance 4s Weakness");
+        lore2.add(8, ChatColor.BLUE +"◆ 25% Chance ♡ Lifesteal");
+        lore2.add(9, ChatColor.BLUE +"◆ 20% Chance 180° rotation");
+        lore2.add(10,ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -201,45 +183,43 @@ public class MysteryStick10 extends SlimefunItem {
 
     public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_10);
+
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 3;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Why is this stick too good") && p.getLevel() <= 25) {
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "Deadly or creepy stick");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.SWEEPING_EDGE);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.FIRE_ASPECT);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
 
-            }
+        if (p.getLevel() <= 25) {
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.set(0, ChatColor.WHITE + "Deadly or creepy stick");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.SWEEPING_EDGE);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.FIRE_ASPECT);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick11.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick11.java
@@ -30,8 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick11 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -62,23 +60,6 @@ public class MysteryStick11 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Behind your enemies awaits danger");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        lore.add("");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 35% Chance 5s Slow");
-        lore.add(ChatColor.BLUE +"◆ 40% Chance 4s Weakness");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 5s Hunger");
-        lore.add(ChatColor.BLUE +"◆ 25% Chance tp behind opponent");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 20, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 18, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 18, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -86,22 +67,13 @@ public class MysteryStick11 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 20, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 18, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 18, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_AXE)) {
             item1.setType(Material.DIAMOND_AXE);
@@ -129,19 +101,18 @@ public class MysteryStick11 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 35) {
                 player.setLevel(player.getLevel() - 4);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
                 LivingEntity victim = (LivingEntity) event.getEntity();
-                if(ThreadLocalRandom.current().nextInt(100) < 35){
+                if(ThreadLocalRandom.current().nextInt(100) < 35 && !(victim.hasPotionEffect(PotionEffectType.SLOW))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 100, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 40){
+                if(ThreadLocalRandom.current().nextInt(100) < 40 && !(victim.hasPotionEffect(PotionEffectType.WEAKNESS))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 80, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.HUNGER))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 100, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 25){
+                if(ThreadLocalRandom.current().nextInt(100) < 10){
                     double nX;
                     double nZ;
                     float nang = victim.getLocation().getYaw() + 90;
@@ -166,24 +137,35 @@ public class MysteryStick11 extends SlimefunItem {
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 25");
             transformWeapon(player, item);
         }
+
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Behind your enemies awaits danger");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        lore2.add(3, "");
+        lore2.add(4, ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        lore2.add(5, ChatColor.BLUE +"◆ 35% Chance 5s Slow");
+        lore2.add(6, ChatColor.BLUE +"◆ 40% Chance 4s Weakness");
+        lore2.add(7, ChatColor.BLUE +"◆ 30% Chance 5s Hunger");
+        lore2.add(8, ChatColor.BLUE +"◆ 10% Chance tp behind opponent");
+        lore2.add(9, ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -198,39 +180,37 @@ public class MysteryStick11 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_11);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 3;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Behind your enemies awaits danger") && p.getLevel() <= 25) {
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "The stick of the nords");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 25) {
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.set(0, ChatColor.WHITE + "The stick of the nords");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick2.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick2 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -61,16 +59,6 @@ public class MysteryStick2 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Another stick of wrecking");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 3, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 2, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 3, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -78,22 +66,13 @@ public class MysteryStick2 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 3, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 2, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 3, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_AXE)) {
             item1.setType(Material.DIAMOND_AXE);
@@ -119,7 +98,6 @@ public class MysteryStick2 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 20) {
                 player.setLevel(player.getLevel() - 1);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -128,23 +106,26 @@ public class MysteryStick2 extends SlimefunItem {
             transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Another stick of wrecking");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -159,32 +140,30 @@ public class MysteryStick2 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_2);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Another stick of wrecking") && p.getLevel() <= 5) {
-                    lore.set(index, ChatColor.WHITE + "Another stick of no matter what is it");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 5) {
+            lore.set(0, ChatColor.WHITE + "Another stick of no matter what is it");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick3.java
@@ -29,8 +29,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick3 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -61,15 +59,6 @@ public class MysteryStick3 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "I knew it was something about shooting arrows");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 3, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 4, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -77,22 +66,12 @@ public class MysteryStick3 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.ARROW_DAMAGE, 3, true);
+        meta.addEnchant(Enchantment.ARROW_INFINITE, 4, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.BOW)) {
             item1.setType(Material.BOW);
@@ -112,22 +91,18 @@ public class MysteryStick3 extends SlimefunItem {
         }
 
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
+
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
 
         if(player.getLevel() <= 5) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -136,6 +111,13 @@ public class MysteryStick3 extends SlimefunItem {
             transformWeapon(player, item);
         }
 
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "I knew it was something about shooting arrows");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -150,31 +132,29 @@ public class MysteryStick3 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_3);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("I knew it was something about shooting arrows") && p.getLevel() <= 5) {
-                    lore.set(index, ChatColor.WHITE + "I feel coordinated when holding this stick");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.ARROW_DAMAGE);
-                    meta.removeEnchant(Enchantment.ARROW_INFINITE);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 5) {
+            lore.set(0, ChatColor.WHITE + "I feel coordinated when holding this stick");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.ARROW_DAMAGE);
+            meta.removeEnchant(Enchantment.ARROW_INFINITE);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick4.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick4 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -61,18 +59,6 @@ public class MysteryStick4 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "It was indeed a magical improvement");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 7, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 8, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 5, true);
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 6, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -80,22 +66,18 @@ public class MysteryStick4 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        lore2.add(0,ChatColor.GOLD + "It was indeed a magical improvement");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 7, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 8, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 5, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 6, true);
+        meta.setUnbreakable(true);
+        meta.setLore(lore2);
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_SWORD)) {
             item1.setType(Material.DIAMOND_SWORD);
@@ -122,7 +104,6 @@ public class MysteryStick4 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 25) {
                 player.setLevel(player.getLevel() - 2);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -131,23 +112,26 @@ public class MysteryStick4 extends SlimefunItem {
             transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "It was indeed a magical improvement");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -162,34 +146,32 @@ public class MysteryStick4 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_4);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("It was indeed a magical improvement") && p.getLevel() <= 15) {
-                    lore.set(index, ChatColor.WHITE + "Did I use this before or maybe not");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.SWEEPING_EDGE);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.FIRE_ASPECT);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 15) {
+            lore.set(0, ChatColor.WHITE + "Did I use this before or maybe not");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.SWEEPING_EDGE);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.FIRE_ASPECT);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick5.java
@@ -29,8 +29,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick5 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -61,17 +59,6 @@ public class MysteryStick5 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Another stick of somewhat reckoning");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 5, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 5, true);
-        meta.addEnchant(Enchantment.KNOCKBACK, 4, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -79,22 +66,14 @@ public class MysteryStick5 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 6, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 5, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 5, true);
+        meta.addEnchant(Enchantment.KNOCKBACK, 4, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_AXE)) {
             item1.setType(Material.DIAMOND_AXE);
@@ -121,7 +100,6 @@ public class MysteryStick5 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 25) {
                 player.setLevel(player.getLevel() - 2);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
         }
         else{
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -130,22 +108,26 @@ public class MysteryStick5 extends SlimefunItem {
             transformWeapon(player, item);
         }
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
+
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Another stick of somewhat reckoning");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -160,33 +142,31 @@ public class MysteryStick5 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_5);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Another stick of somewhat reckoning") && p.getLevel() <= 15) {
-                    lore.set(index, ChatColor.WHITE + "I know you are tired of this stick thing");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    meta.removeEnchant(Enchantment.KNOCKBACK);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 15) {
+            lore.set(0, ChatColor.WHITE + "I know you are tired of this stick thing");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            meta.removeEnchant(Enchantment.KNOCKBACK);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick6.java
@@ -29,8 +29,6 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick6 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -61,17 +59,6 @@ public class MysteryStick6 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Make them take an arrow to the knee");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 7, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 5, true);
-        meta.addEnchant(Enchantment.ARROW_FIRE, 6, true);
-        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 7, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -79,22 +66,14 @@ public class MysteryStick6 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.ARROW_DAMAGE, 7, true);
+        meta.addEnchant(Enchantment.ARROW_INFINITE, 5, true);
+        meta.addEnchant(Enchantment.ARROW_FIRE, 6, true);
+        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 7, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.BOW)) {
             item1.setType(Material.BOW);
@@ -115,22 +94,18 @@ public class MysteryStick6 extends SlimefunItem {
         }
 
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
+
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
 
         if(player.getLevel() <= 15) {
             player.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 300, 2, false, false));
@@ -139,6 +114,13 @@ public class MysteryStick6 extends SlimefunItem {
             transformWeapon(player, item);
         }
 
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Make them take an arrow to the knee");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -153,33 +135,31 @@ public class MysteryStick6 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_6);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 1;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Make them take an arrow to the knee") && p.getLevel() <= 15) {
-                    lore.set(index, ChatColor.WHITE + "May the force and accuracy be with you");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.ARROW_DAMAGE);
-                    meta.removeEnchant(Enchantment.ARROW_INFINITE);
-                    meta.removeEnchant(Enchantment.ARROW_FIRE);
-                    meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 15) {
+            lore.set(0, ChatColor.WHITE + "May the force and accuracy be with you");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.ARROW_DAMAGE);
+            meta.removeEnchant(Enchantment.ARROW_INFINITE);
+            meta.removeEnchant(Enchantment.ARROW_FIRE);
+            meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick7.java
@@ -62,24 +62,6 @@ public class MysteryStick7 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "Blood will spit across the land");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        lore.add("");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 35% Chance 3s Poison");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Wither");
-        lore.add(ChatColor.BLUE +"◆ 25% Chance 4s Weakness");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.SWEEPING_EDGE, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 17, true);
-        meta.addEnchant(Enchantment.FIRE_ASPECT, 10, true);
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 13, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -87,22 +69,15 @@ public class MysteryStick7 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.SWEEPING_EDGE, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 17, true);
+        meta.addEnchant(Enchantment.FIRE_ASPECT, 10, true);
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 13, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_SWORD)) {
             item1.setType(Material.DIAMOND_SWORD);
@@ -130,16 +105,15 @@ public class MysteryStick7 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 30) {
                 player.setLevel(player.getLevel() - 3);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
                 LivingEntity victim = (LivingEntity) event.getEntity();
-                if(ThreadLocalRandom.current().nextInt(100) < 35){
+                if(ThreadLocalRandom.current().nextInt(100) < 35 && !(victim.hasPotionEffect(PotionEffectType.POISON))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.POISON, 60, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.WITHER))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 80, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 25){
+                if(ThreadLocalRandom.current().nextInt(100) < 25 && !(victim.hasPotionEffect(PotionEffectType.WEAKNESS))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 80, 1, false, true));
                 }
             } else {
@@ -152,24 +126,34 @@ public class MysteryStick7 extends SlimefunItem {
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
             transformWeapon(player, item);
         }
+
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "Blood will spit across the land");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        lore2.add(3,"");
+        lore2.add(4, ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        lore2.add(5, ChatColor.BLUE +"◆ 35% Chance 3s Poison");
+        lore2.add(6, ChatColor.BLUE +"◆ 30% Chance 4s Wither");
+        lore2.add(7, ChatColor.BLUE +"◆ 25% Chance 4s Weakness");
+        lore2.add(8, ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -184,40 +168,38 @@ public class MysteryStick7 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_7);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 2;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Blood will spit across the land") && p.getLevel() <= 20) {
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "The aura on this stick is mesmerizing");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.SWEEPING_EDGE);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.FIRE_ASPECT);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 20) {
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.set(0, ChatColor.WHITE + "The aura on this stick is mesmerizing");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.SWEEPING_EDGE);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.FIRE_ASPECT);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick8.java
@@ -30,8 +30,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick8 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -62,23 +60,6 @@ public class MysteryStick8 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "I'm out of words using this");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        lore.add("");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Slow");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 3s Weakness");
-        lore.add(ChatColor.BLUE +"◆ 25% Chance 4s Hunger");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 15, true);
-        meta.addEnchant(Enchantment.DAMAGE_ALL, 13, true);
-        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
-        meta.addEnchant(Enchantment.KNOCKBACK, 10, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -86,22 +67,14 @@ public class MysteryStick8 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.DAMAGE_ARTHROPODS, 15, true);
+        meta.addEnchant(Enchantment.DAMAGE_ALL, 13, true);
+        meta.addEnchant(Enchantment.DAMAGE_UNDEAD, 13, true);
+        meta.addEnchant(Enchantment.KNOCKBACK, 10, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.DIAMOND_AXE)) {
             item1.setType(Material.DIAMOND_AXE);
@@ -129,16 +102,15 @@ public class MysteryStick8 extends SlimefunItem {
             if(ThreadLocalRandom.current().nextInt(100) < 30) {
                 player.setLevel(player.getLevel() - 3);
             }
-            event.getDamager().getWorld().playEffect(event.getEntity().getLocation(), Effect.MOBSPAWNER_FLAMES, 1);
             if(event.getEntity() instanceof LivingEntity) {
                 LivingEntity victim = (LivingEntity) event.getEntity();
-                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.SLOW))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, 80, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 30){
+                if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.WEAKNESS))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.WEAKNESS, 60, 1, false, true));
                 }
-                if(ThreadLocalRandom.current().nextInt(100) < 25){
+                if(ThreadLocalRandom.current().nextInt(100) < 25 && !(victim.hasPotionEffect(PotionEffectType.HUNGER))){
                     victim.addPotionEffect(new PotionEffect(PotionEffectType.HUNGER, 80, 1, false, true));
                 }
             } else {
@@ -151,24 +123,34 @@ public class MysteryStick8 extends SlimefunItem {
             player.sendMessage(ChatColor.RED + "" + ChatColor.BOLD  + "[FNAmpli" + ChatColor.AQUA + "" + ChatColor.BOLD + "fications] > " + ChatColor.YELLOW + "You're too weak, make sure your exp level is higher than 20");
             transformWeapon(player, item);
         }
+
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
 
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
+
+    }
+
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "I'm out of words using this");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        lore2.add(3,"");
+        lore2.add(4, ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        lore2.add(5, ChatColor.BLUE +"◆ 30% Chance 4s Slow");
+        lore2.add(6, ChatColor.BLUE +"◆ 30% Chance 3s Weakness");
+        lore2.add(7, ChatColor.BLUE +"◆ 25% Chance 4s Hunger");
+        lore2.add(8, ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        return lore2;
     }
 
     public void LevelChange(PlayerLevelChangeEvent event){
@@ -183,39 +165,37 @@ public class MysteryStick8 extends SlimefunItem {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_8);
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 2;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("I'm out of words using this") && p.getLevel() <= 20) {
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "This stick is kinda heavy");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
-                    meta.removeEnchant(Enchantment.DAMAGE_ALL);
-                    meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
-                    meta.removeEnchant(Enchantment.KNOCKBACK);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 20) {
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.set(0, ChatColor.WHITE + "This stick is kinda heavy");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.DAMAGE_ARTHROPODS);
+            meta.removeEnchant(Enchantment.DAMAGE_ALL);
+            meta.removeEnchant(Enchantment.DAMAGE_UNDEAD);
+            meta.removeEnchant(Enchantment.KNOCKBACK);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override

--- a/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick9.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/MysteriousItems/MysteryStick9.java
@@ -31,8 +31,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
 
-import static org.bukkit.ChatColor.stripColor;
-
 public class MysteryStick9 extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
@@ -63,23 +61,6 @@ public class MysteryStick9 extends SlimefunItem {
         ItemStack item1 = player.getInventory().getItemInMainHand();
 
         ItemMeta meta = item1.getItemMeta();
-        ArrayList<String> lore = new ArrayList<>();
-        lore.add(ChatColor.GOLD + "I wonder if Elves possess this relic");
-        lore.add(ChatColor.YELLOW + "Exp Levels Consumed:");
-        lore.add(ChatColor.YELLOW + "Total Damage inflicted:");
-        lore.add("");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        lore.add(ChatColor.BLUE +"◆ 35% Chance 3s Levitation");
-        lore.add(ChatColor.BLUE +"◆ 30% Chance 4s Harm");
-        lore.add(ChatColor.BLUE +"◆ 20% Chance 3s Blindness");
-        lore.add(ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
-        meta.addEnchant(Enchantment.ARROW_DAMAGE, 15, true);
-        meta.addEnchant(Enchantment.ARROW_INFINITE, 12, true);
-        meta.addEnchant(Enchantment.ARROW_FIRE, 12, true);
-        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 14, true);
-        meta.setLore(lore);
-        meta.setUnbreakable(true);
-        item1.setItemMeta(meta);
         NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
@@ -87,22 +68,14 @@ public class MysteryStick9 extends SlimefunItem {
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         int damageAll = damageAmount.getOrDefault(key2, PersistentDataType.INTEGER, 0);
 
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageAll);
-                    meta.setLore(lore2);
-                    item1.setItemMeta(meta);
-                }
-            }
-        }
+        List<String> lore2 = new ArrayList<>();
+        meta.addEnchant(Enchantment.ARROW_DAMAGE, 15, true);
+        meta.addEnchant(Enchantment.ARROW_INFINITE, 12, true);
+        meta.addEnchant(Enchantment.ARROW_FIRE, 12, true);
+        meta.addEnchant(Enchantment.ARROW_KNOCKBACK, 14, true);
+        meta.setUnbreakable(true);
+        meta.setLore(loreUpdate(lore2, damageAll, xpamount));
+        item1.setItemMeta(meta);
 
         if(!(item1.getType() == Material.BOW)) {
             item1.setType(Material.BOW);
@@ -124,32 +97,28 @@ public class MysteryStick9 extends SlimefunItem {
         }
 
         ItemMeta meta = item.getItemMeta();
+        NamespacedKey key = getStorageKey();
         NamespacedKey key2 = getStorageKey2();
+        PersistentDataContainer expUsed = meta.getPersistentDataContainer();
         PersistentDataContainer damage = meta.getPersistentDataContainer();
         int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int get_Damage = (int) event.getDamage() + damageamount;
+        int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
         damage.set(key2, PersistentDataType.INTEGER, get_Damage);
-        List<String> lore2 = meta.getLore();
-        if (lore2 != null && !lore2.isEmpty()) {
-            for (int index = 0; index < lore2.size(); index++) {
-                String line = lore2.get(index);
-                if (stripColor(line).startsWith("Total Damage inflicted:")) {
-                    lore2.set(index, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
-                    meta.setLore(lore2);
-                    item.setItemMeta(meta);
-                }
-            }
-        }
+
+        List<String> lore2 = new ArrayList<>();
+        meta.setLore(loreUpdate(lore2, get_Damage, xpamount));
+        item.setItemMeta(meta);
 
         if(event.getEntity() instanceof LivingEntity) {
             LivingEntity victim = (LivingEntity) event.getEntity();
-            if(ThreadLocalRandom.current().nextInt(100) < 35){
+            if(ThreadLocalRandom.current().nextInt(100) < 35 && !(victim.hasPotionEffect(PotionEffectType.LEVITATION))){
                 victim.addPotionEffect(new PotionEffect(PotionEffectType.LEVITATION, 60, 1, false, true));
             }
-            if(ThreadLocalRandom.current().nextInt(100) < 30){
+            if(ThreadLocalRandom.current().nextInt(100) < 30 && !(victim.hasPotionEffect(PotionEffectType.HARM))){
                 victim.addPotionEffect(new PotionEffect(PotionEffectType.HARM, 80, 1, false, true));
             }
-            if(ThreadLocalRandom.current().nextInt(100) < 20){
+            if(ThreadLocalRandom.current().nextInt(100) < 20 && !(victim.hasPotionEffect(PotionEffectType.BLINDNESS))){
                 victim.addPotionEffect(new PotionEffect(PotionEffectType.BLINDNESS, 60, 1, false, true));
             }
         }
@@ -162,6 +131,19 @@ public class MysteryStick9 extends SlimefunItem {
         }
     }
 
+    public List<String> loreUpdate(List<String> lore2, int get_Damage, int xpamount){
+        lore2.add(0,ChatColor.GOLD + "I wonder if Elves possess this relic");
+        lore2.add(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + xpamount);
+        lore2.add(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + get_Damage);
+        lore2.add(3, "");
+        lore2.add(4, ChatColor.RED + "◢◤◢◤◢◤◢◤| "+ ChatColor.DARK_RED + "" + ChatColor.BOLD + "Effects " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        lore2.add(5, ChatColor.BLUE +"◆ 35% Chance 3s Levitation");
+        lore2.add(6, ChatColor.BLUE +"◆ 30% Chance 4s Harm");
+        lore2.add(7, ChatColor.BLUE +"◆ 20% Chance 3s Blindness");
+        lore2.add(8, ChatColor.RED + "◢◤◢◤◢◤◢◤| " + ChatColor.DARK_RED + "  ◢◤◤◥◤◥◥◣   " + ChatColor.WHITE + "|◥◣◥◣◥◣◥◣");
+        return lore2;
+    }
+
     public void LevelChange(PlayerLevelChangeEvent event){
         Player p = event.getPlayer();
         ItemStack item = p.getInventory().getItemInMainHand();
@@ -172,41 +154,40 @@ public class MysteryStick9 extends SlimefunItem {
 
     public void transformWeapon(Player p, ItemStack item) {
         CustomItemStack item2 = new CustomItemStack(FNAmpItems.FN_STICK_9);
+
         ItemMeta meta = item.getItemMeta();
         NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
         PersistentDataContainer expUsed = meta.getPersistentDataContainer();
+        PersistentDataContainer damage = meta.getPersistentDataContainer();
         int xpamount = expUsed.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int damageamount = damage.getOrDefault(key2, PersistentDataType.INTEGER, 0);
         int amount = ++xpamount + 2;
         expUsed.set(key, PersistentDataType.INTEGER, amount);
-        List<String> lore = meta.getLore();
 
-        if (lore != null && !lore.isEmpty()) {
-            for (int index = 0; index < lore.size(); index++) {
-                String line = lore.get(index);
-                if (stripColor(line).startsWith("Exp Levels Consumed:")) {
-                    lore.set(index, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    item.setItemMeta(meta);
-                }
-                if (stripColor(line).startsWith("I wonder if Elves possess this relic") && p.getLevel() <= 20) {
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.remove(3);
-                    lore.set(index, ChatColor.WHITE + "You need more mana when using this");
-                    lore.set(index+1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
-                    meta.setLore(lore);
-                    meta.removeEnchant(Enchantment.ARROW_DAMAGE);
-                    meta.removeEnchant(Enchantment.ARROW_INFINITE);
-                    meta.removeEnchant(Enchantment.ARROW_FIRE);
-                    meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
-                    item.setItemMeta(meta);
-                    item.setType(item2.getType());
-                }
-            }
+        List<String> lore = new ArrayList<>();
+        meta.setLore(loreUpdate(lore, damageamount, amount));
+        item.setItemMeta(meta);
+
+        if (p.getLevel() <= 20) {
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.remove(3);
+            lore.set(0, ChatColor.WHITE + "You need more mana when using this");
+            lore.set(1, ChatColor.YELLOW + "Exp Levels Consumed: " + ChatColor.WHITE + amount);
+            lore.set(2, ChatColor.YELLOW + "Total Damage inflicted: " + ChatColor.WHITE + damageamount);
+            meta.setLore(lore);
+            meta.removeEnchant(Enchantment.ARROW_DAMAGE);
+            meta.removeEnchant(Enchantment.ARROW_INFINITE);
+            meta.removeEnchant(Enchantment.ARROW_FIRE);
+            meta.removeEnchant(Enchantment.ARROW_KNOCKBACK);
+            item.setItemMeta(meta);
+            item.setType(item2.getType());
         }
+
     }
 
     @Override


### PR DESCRIPTION
## Changes
- Added new FN Gears of Friction, these gears have its simple levelling system and it gives bonus attributes or enchants everytime the gear has levelled up. To gain progress, the player should get hit while wearing the gear and it will increment the progress bar inside the lore of the gear and this happens by certain chance. For every gear level up,  the current value of the progress bar will be increased by 80-100. Bonus attributes range from additional armor, armor toughness, knockback resistance and even additional speed attribute for the boots when worn. New Enchantments will be applied or old ones upgraded for every gear level up.
- Metal Scrap chance on downgrader from 33% to 20%
- Optimized the code for mystery sticks (removed effects, etc)

## Related Issues
TBD

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
