### PR TITLE
Staff max uses configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.7.9</version>
+    <version>2.8.0</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
@@ -392,4 +392,16 @@ public class ReturnConfValue {
     public int blockBreaker3Ticks() {
         return config.getInt("E-block-breaker3-tickRate");
     }
+
+    public int staffOfLocomotion() {
+        return config.getInt("Staff-of-Locomotion");
+    }
+
+    public int staffOfInvisibility() {
+        return config.getInt("Staff-of-Invisibility");
+    }
+
+    public int staffOfTeleportation() {
+        return config.getInt("Staff-of-Teleportation");
+    }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -1111,7 +1111,6 @@ public class FNAmpItems {
 
     );
 
-
     public static final SlimefunItemStack FN_STAFF_TP = new SlimefunItemStack(
             "FN_STAFF_TP",
             Material.BLAZE_ROD,
@@ -1120,7 +1119,7 @@ public class FNAmpItems {
             "&dTeleport to a target block by",
             "&dright clicking it",
             "",
-            "&eUses left: 10"
+            "&eUses left: " + value.staffOfTeleportation()
     );
 
     public static final SlimefunItemStack FN_STAFF_INVI = new SlimefunItemStack(
@@ -1131,7 +1130,7 @@ public class FNAmpItems {
             "&d6 seconds of invisibility",
             "&deven your armor and name is hidden",
             "",
-            "&eUses left: 10"
+            "&eUses left: "  + value.staffOfInvisibility()
     );
 
     public static final SlimefunItemStack FN_STAFF_LOCOMOTION = new SlimefunItemStack(
@@ -1142,7 +1141,7 @@ public class FNAmpItems {
             "&dMove entities to a target location by right",
             "&dclicking to select and left click to move",
             "",
-            "&eUses left: 10"
+            "&eUses left: " + value.staffOfLocomotion()
     );
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
@@ -59,7 +59,7 @@ public class StaffListener implements Listener {
             return;
         }
 
-        if (stick instanceof StaffOfLocomotion && e.getHand().equals(EquipmentSlot.HAND)) {
+        if (stick instanceof StaffOfLocomotion && e.getHand() == EquipmentSlot.HAND) {
             if (e.getRightClicked() instanceof LivingEntity && !(e.getRightClicked() instanceof Player)) {
                 ((StaffOfLocomotion) stick).onRightClick(e);
             } else {

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfInvisibility.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfInvisibility.java
@@ -6,14 +6,13 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
-import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
-import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataContainer;
@@ -28,6 +27,8 @@ import java.util.*;
 public class StaffOfInvisibility extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
 
@@ -57,8 +58,8 @@ public class StaffOfInvisibility extends SlimefunItem {
 
         for(Player online : Bukkit.getOnlinePlayers()){
             online.hidePlayer((Plugin) plugin, player);
-            PotionEffect effect = new PotionEffect(PotionEffectType.GLOWING,110,1, false, false);
-            PotionEffect effect2 = new PotionEffect(PotionEffectType.INVISIBILITY,110,1, false, false);
+            PotionEffect effect = new PotionEffect(PotionEffectType.GLOWING,115,1, false, false);
+            PotionEffect effect2 = new PotionEffect(PotionEffectType.INVISIBILITY,115,1, false, false);
             player.addPotionEffect(effect);
             player.addPotionEffect(effect2);
         }
@@ -78,7 +79,7 @@ public class StaffOfInvisibility extends SlimefunItem {
 
     public void updateMeta(ItemStack item, ItemMeta meta, NamespacedKey key, Player player){
         PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
-        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, 10);
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfInvisibility());
         int decrement = uses_Left - 1;
 
         List<String> lore = new ArrayList<>();

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfLocomotion.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfLocomotion.java
@@ -8,6 +8,7 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -30,6 +31,8 @@ public class StaffOfLocomotion extends SlimefunItem {
     private final Map<PersistentDataContainer, LivingEntity> ENTITY_OWNER = new HashMap<>();
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
 
@@ -66,7 +69,7 @@ public class StaffOfLocomotion extends SlimefunItem {
         PersistentDataContainer data = meta.getPersistentDataContainer();
         PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
 
-        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, 10);
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfLocomotion());
 
         List<String> lore = new ArrayList<>();
 
@@ -145,7 +148,7 @@ public class StaffOfLocomotion extends SlimefunItem {
 
     public void updateMeta(ItemStack item, ItemMeta meta, NamespacedKey key, Player player){
         PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
-        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, 10);
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfLocomotion());
         int decrement = uses_Left - 1;
 
         List<String> lore = new ArrayList<>();

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfTeleportation.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfTeleportation.java
@@ -8,13 +8,12 @@ import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
-import ne.fnfal113.fnamplifications.Multiblock.FnMysteryStickAltar;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.block.data.Directional;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
@@ -31,6 +30,8 @@ import java.util.Objects;
 public class StaffOfTeleportation extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
 
@@ -80,7 +81,7 @@ public class StaffOfTeleportation extends SlimefunItem {
 
     public void updateMeta(ItemStack item, ItemMeta meta, NamespacedKey key, Player player){
         PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
-        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, 10);
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfTeleportation());
         int decrement = uses_Left - 1;
 
         List<String> lore = new ArrayList<>();
@@ -111,7 +112,6 @@ public class StaffOfTeleportation extends SlimefunItem {
             ALT_RECIPE = alt_recipe.getItem().clone();
         }
     }
-
 
     public static void setup(){
         new StaffOfTeleportation(FNAmpItems.FN_STAFFS, FNAmpItems.FN_STAFF_TP, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -176,3 +176,8 @@ Tier8-Lore: "&eGenerator works during Day only"
 E-block-breaker1-tickRate: 12
 E-block-breaker2-tickRate: 6
 E-block-breaker3-tickRate: 2
+
+# Modify here the Staff max uses value
+Staff-of-Locomotion: 10
+Staff-of-Invisibility: 10
+Staff-of-Teleportation: 10


### PR DESCRIPTION
## Changes
- Max uses for staffs can now be modified in config.yml (requires server restart)

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
