### PR TITLE
Quivers and gears configurability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.8.0</version>
+    <version>2.8.1</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
@@ -404,4 +404,21 @@ public class ReturnConfValue {
     public int staffOfTeleportation() {
         return config.getInt("Staff-of-Teleportation");
     }
+
+    public boolean fnHelmetUnbreakable(){
+        return config.getBoolean("FN-Helmet-Unbreakable");
+    }
+
+    public boolean fnChestPlateUnbreakable(){
+        return config.getBoolean("FN-Chestplate-Unbreakable");
+    }
+
+    public boolean fnLeggingsUnbreakable(){
+        return config.getBoolean("FN-Leggings-Unbreakable");
+    }
+
+    public boolean fnBootsUnbreakable(){
+        return config.getBoolean("FN-boots-Unbreakable");
+    }
+
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.updater.GitHubBuildsUp
 
 import ne.fnfal113.fnamplifications.Gears.Listeners.GearListener;
 import ne.fnfal113.fnamplifications.MysteriousItems.Listeners.MysteryStickListener;
+import ne.fnfal113.fnamplifications.Quiver.Listener.QuiverListener;
 import ne.fnfal113.fnamplifications.Staffs.Listener.StaffListener;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -35,6 +36,7 @@ public final class FNAmplifications extends JavaPlugin implements SlimefunAddon 
         getServer().getPluginManager().registerEvents(new MysteryStickListener(), this);
         getServer().getPluginManager().registerEvents(new GearListener(), this);
         getServer().getPluginManager().registerEvents(new StaffListener(), this);
+        getServer().getPluginManager().registerEvents(new QuiverListener(), this);
 
         getConfig().options().copyDefaults();
         saveDefaultConfig();

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -30,13 +31,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.bukkit.ChatColor.stripColor;
 
 public class FnBoots extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
     private final NamespacedKey defaultUsageKey2;
@@ -74,8 +74,15 @@ public class FnBoots extends SlimefunItem {
         }
 
         Player p = ((Player) event.getEntity()).getPlayer();
+
+        if(p == null){
+            return;
+        }
         ItemStack itemStack = p.getInventory().getBoots();
 
+        if(itemStack == null){
+            return;
+        }
         ItemMeta meta = itemStack.getItemMeta();
 
         if (meta == null) {
@@ -358,12 +365,22 @@ public class FnBoots extends SlimefunItem {
         return false;
     }
 
+    public final FnBoots setUnbreakable(boolean unbreakable) {
+        ItemMeta meta = this.getItem().getItemMeta();
+        if(meta == null){
+            return this;
+        }
+        meta.setUnbreakable(unbreakable);
+        this.getItem().setItemMeta(meta);
+        return this;
+    }
+
     public static void setup(){
         new FnBoots(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_BOOTS, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
                 new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 5), new ItemStack(Material.IRON_BOOTS), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 5),
                 SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 6), SlimefunItems.ENCHANTMENT_RUNE,
                 new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6), new ItemStack(Material.DIAMOND_BOOTS), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6)})
-                .register(plugin);
+                .setUnbreakable(value.fnBootsUnbreakable()).register(plugin);
     }
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnChestPlate.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnChestPlate.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -28,13 +29,12 @@ import org.bukkit.persistence.PersistentDataType;
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.bukkit.ChatColor.stripColor;
 
 public class FnChestPlate extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
     private final NamespacedKey defaultUsageKey2;
@@ -72,8 +72,15 @@ public class FnChestPlate extends SlimefunItem {
         }
 
         Player p = ((Player) event.getEntity()).getPlayer();
+
+        if(p == null){
+            return;
+        }
         ItemStack itemStack = p.getInventory().getChestplate();
 
+        if(itemStack == null){
+            return;
+        }
         ItemMeta meta = itemStack.getItemMeta();
 
         if (meta == null) {
@@ -92,7 +99,7 @@ public class FnChestPlate extends SlimefunItem {
         int total = amount + 1;
         progress.set(key, PersistentDataType.INTEGER, total);
 
-        List<String> lore = new ArrayList<>();;
+        List<String> lore = new ArrayList<>();
 
         if (total >= 0) {
             lore.add(0, ChatColor.RED + "◬◬◬◬◬◬| "+ ChatColor.LIGHT_PURPLE + ""
@@ -265,7 +272,7 @@ public class FnChestPlate extends SlimefunItem {
             armor.setItemMeta(meta);
             levelUp(p);
         } else if (level == 25){
-            meta.addEnchant(Enchantment.THORNS, 20, true);
+            meta.addEnchant(Enchantment.PROTECTION_FIRE, 20, true);
             meta.removeAttributeModifier(EquipmentSlot.CHEST);
             armor.setItemMeta(meta);
             meta.addAttributeModifier(Attribute.GENERIC_ARMOR, new AttributeModifier(UUID.randomUUID(), "generic.armorBonus.chest", 12.0, AttributeModifier.Operation.ADD_NUMBER, EquipmentSlot.CHEST));
@@ -309,12 +316,22 @@ public class FnChestPlate extends SlimefunItem {
         return false;
     }
 
+    public final FnChestPlate setUnbreakable(boolean unbreakable) {
+        ItemMeta meta = this.getItem().getItemMeta();
+        if(meta == null){
+            return this;
+        }
+        meta.setUnbreakable(unbreakable);
+        this.getItem().setItemMeta(meta);
+        return this;
+    }
+
     public static void setup(){
         new FnChestPlate(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_CHESTPLATE, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
                 new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2), new ItemStack(Material.IRON_CHESTPLATE), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2),
                 SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 4), SlimefunItems.ENCHANTMENT_RUNE,
                 new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 4), new ItemStack(Material.DIAMOND_CHESTPLATE), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 4)})
-                .register(plugin);
+                .setUnbreakable(value.fnChestPlateUnbreakable()).register(plugin);
     }
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnHelmet.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnHelmet.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -30,13 +31,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.bukkit.ChatColor.stripColor;
 
 public class FnHelmet extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
     private final NamespacedKey defaultUsageKey2;
@@ -73,10 +73,16 @@ public class FnHelmet extends SlimefunItem {
             return;
         }
 
-
         Player p = ((Player) event.getEntity()).getPlayer();
+
+        if(p == null){
+            return;
+        }
         ItemStack itemStack = p.getInventory().getHelmet();
 
+        if(itemStack == null){
+            return;
+        }
         ItemMeta meta = itemStack.getItemMeta();
 
         if (meta == null) {
@@ -336,12 +342,22 @@ public class FnHelmet extends SlimefunItem {
         return false;
     }
 
+    public final FnHelmet setUnbreakable(boolean unbreakable) {
+        ItemMeta meta = this.getItem().getItemMeta();
+        if(meta == null){
+            return this;
+        }
+        meta.setUnbreakable(unbreakable);
+        this.getItem().setItemMeta(meta);
+        return this;
+    }
+
     public static void setup(){
         new FnHelmet(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_HELMET, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
                 new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 4), new ItemStack(Material.IRON_HELMET), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 4),
                 SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 5), SlimefunItems.ENCHANTMENT_RUNE,
                 new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6), new ItemStack(Material.DIAMOND_HELMET), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 6)})
-                .register(plugin);
+                .setUnbreakable(value.fnHelmetUnbreakable()).register(plugin);
     }
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnLeggings.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnLeggings.java
@@ -7,6 +7,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
@@ -30,13 +31,12 @@ import javax.annotation.ParametersAreNonnullByDefault;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.bukkit.ChatColor.stripColor;
 
 public class FnLeggings extends SlimefunItem{
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
 
     private final NamespacedKey defaultUsageKey;
     private final NamespacedKey defaultUsageKey2;
@@ -74,8 +74,15 @@ public class FnLeggings extends SlimefunItem{
         }
 
         Player p = ((Player) event.getEntity()).getPlayer();
+
+        if(p == null){
+            return;
+        }
         ItemStack itemStack = p.getInventory().getLeggings();
 
+        if(itemStack == null){
+            return;
+        }
         ItemMeta meta = itemStack.getItemMeta();
 
         if (meta == null) {
@@ -310,11 +317,21 @@ public class FnLeggings extends SlimefunItem{
         return false;
     }
 
+    public final FnLeggings setUnbreakable(boolean unbreakable) {
+        ItemMeta meta = this.getItem().getItemMeta();
+        if(meta == null){
+            return this;
+        }
+        meta.setUnbreakable(unbreakable);
+        this.getItem().setItemMeta(meta);
+        return this;
+    }
+
     public static void setup() {
         new FnLeggings(FNAmpItems.FN_GEARS, FNAmpItems.FN_GEAR_LEGGINGS, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
                 new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2), new ItemStack(Material.IRON_LEGGINGS), new SlimefunItemStack(SlimefunItems.REINFORCED_PLATE, 2),
                 SlimefunItems.ENCHANTMENT_RUNE, new ItemStack(Material.NETHERITE_INGOT, 3), SlimefunItems.ENCHANTMENT_RUNE,
                 new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 3), new ItemStack(Material.DIAMOND_LEGGINGS), new SlimefunItemStack(SlimefunItems.REINFORCED_ALLOY_INGOT, 3)})
-                .register(plugin);
+                .setUnbreakable(value.fnLeggingsUnbreakable()).register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
@@ -15,6 +15,10 @@ import ne.fnfal113.fnamplifications.Multiblock.FnScrapRecycler;
 import ne.fnfal113.fnamplifications.MysteriousItems.*;
 import ne.fnfal113.fnamplifications.PowerGenerators.FNSolarGenerators;
 import ne.fnfal113.fnamplifications.PowerGenerators.PowahGenerator;
+import ne.fnfal113.fnamplifications.Quiver.Quiver;
+import ne.fnfal113.fnamplifications.Quiver.SpectralQuiver;
+import ne.fnfal113.fnamplifications.Quiver.UpgradedQuiver;
+import ne.fnfal113.fnamplifications.Quiver.UpgradedSpectralQuiver;
 import ne.fnfal113.fnamplifications.Staffs.StaffOfLocomotion;
 import ne.fnfal113.fnamplifications.Staffs.StaffOfInvisibility;
 import ne.fnfal113.fnamplifications.Staffs.StaffOfTeleportation;
@@ -49,6 +53,7 @@ public final class FNAmpItemSetup {
         registerStick();
         registerGear();
         registerStaff();
+        registerQuiver();
     }
 
     private void registerPowerGens() {
@@ -137,5 +142,12 @@ public final class FNAmpItemSetup {
         StaffOfTeleportation.setup();
         StaffOfInvisibility.setup();
         StaffOfLocomotion.setup();
+    }
+
+    public void registerQuiver(){
+        Quiver.setup();
+        SpectralQuiver.setup();
+        UpgradedQuiver.setup();
+        UpgradedSpectralQuiver.setup();
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -119,6 +119,12 @@ public class FNAmpItems {
             new CustomItemStack(Material.BLAZE_ROD,
                     "&eFN_FAL'S Staffs"));
 
+    public static final SubItemGroup FN_MISC = new SubItemGroup(
+            new NamespacedKey(FNAmplifications.getInstance(), "FN_MISC"),
+            FN_ITEMS,
+            new CustomItemStack(Material.CHEST,
+                    "&eFN_FAL'S Miscellaneous"));
+
     public static final ItemGroup FN_AMPLIFICATIONS = new ItemGroup(
             new NamespacedKey(FNAmplifications.getInstance(), "FN_AMPLIFICATIONS"),
             new CustomItemStack(PlayerHead.getItemStack(PlayerSkin.fromHashCode(
@@ -1142,6 +1148,62 @@ public class FNAmpItems {
             "&dclicking to select and left click to move",
             "",
             "&eUses left: " + value.staffOfLocomotion()
+    );
+
+    public static final SlimefunItemStack FN_QUIVER = new SlimefunItemStack(
+            "FN_QUIVER",
+            Material.LEATHER,
+            "&bBow Quiver (Normal)",
+            "",
+            "&dStore inside the quiver",
+            "&dby right clicking arrows or",
+            "&dshift click quiver to withdraw",
+            "",
+            "&eLeft/Right click to change state",
+            "&eSize: 128 Arrows",
+            "&eArrows: " + ChatColor.WHITE + "0"
+    );
+
+    public static final SlimefunItemStack FN_SPECTRAL_QUIVER = new SlimefunItemStack(
+            "FN_SPECTRAL_QUIVER",
+            Material.LEATHER,
+            "&aBow Quiver (Spectral)",
+            "",
+            "&dStore inside the quiver by",
+            "&dright clicking spectral arrows or",
+            "&dshift click quiver to withdraw",
+            "",
+            "&eLeft/Right click to change state",
+            "&eSize: 128 Spectral Arrows",
+            "&eArrows: " + ChatColor.WHITE + "0"
+    );
+
+    public static final SlimefunItemStack FN_UPGRADED_QUIVER = new SlimefunItemStack(
+            "FN_UPGRADED_QUIVER",
+            Material.LEATHER,
+            "&6Upgraded Bow Quiver (Normal)",
+            "",
+            "&dStore inside the quiver",
+            "&dby right clicking arrows or",
+            "&dshift click to withdraw",
+            "",
+            "&eLeft/Right click to change state",
+            "&eSize: 192 Arrows",
+            "&eArrows: " + ChatColor.WHITE + "0"
+    );
+
+    public static final SlimefunItemStack FN_UPGRADED_SPECTRAL_QUIVER = new SlimefunItemStack(
+            "FN_UPGRADED_SPECTRAL_QUIVER",
+            Material.LEATHER,
+            "&cUpgraded Bow Quiver (Spectral)",
+            "",
+            "&dStore inside the quiver",
+            "&dby right clicking spectral arrows or",
+            "&dshift click quiver to withdraw",
+            "",
+            "&eLeft/Right click to change state",
+            "&eSize: 192 Arrows",
+            "&eArrows: " + ChatColor.WHITE + "0"
     );
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Quiver/Listener/QuiverListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Quiver/Listener/QuiverListener.java
@@ -1,0 +1,195 @@
+package ne.fnfal113.fnamplifications.Quiver.Listener;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import ne.fnfal113.fnamplifications.Quiver.Quiver;
+import ne.fnfal113.fnamplifications.Quiver.SpectralQuiver;
+import ne.fnfal113.fnamplifications.Quiver.UpgradedQuiver;
+import ne.fnfal113.fnamplifications.Quiver.UpgradedSpectralQuiver;
+import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class QuiverListener implements Listener {
+
+    // Commented out for optimizations (Unused Event)
+    /*@EventHandler
+    public void checkCrossBow(PlayerItemHeldEvent event){
+        Player player = event.getPlayer();
+        int slot = event.getNewSlot();
+        ItemStack itemStack = player.getInventory().getItem(slot);*/
+
+        /*if(itemStack != null && itemStack.getType() == Material.CROSSBOW) {
+            for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+
+                if (sfItem instanceof Quiver) {
+                    ItemStack itemStack1 = player.getInventory().getItem(i);
+
+                    if(itemStack1 == null){
+                        return;
+                    }
+                    player.sendMessage("Quiver doesn't support crossbows, change slot to bow to change quiver back to arrow");
+                    itemStack1.setType(Material.LEATHER);
+                }
+
+            }
+        } else*/
+        /*if(itemStack != null){
+            for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+
+                if (sfItem instanceof Quiver) {
+                    ((Quiver) sfItem).checkBow(event);
+                }
+
+                if (sfItem instanceof SpectralQuiver) {
+                    ((SpectralQuiver) sfItem).checkBow(event);
+                }
+
+                if (sfItem instanceof UpgradedQuiver) {
+                    ((UpgradedQuiver) sfItem).checkBow(event);
+                }
+
+                if (sfItem instanceof UpgradedSpectralQuiver) {
+                    ((UpgradedSpectralQuiver) sfItem).checkBow(event);
+                }
+
+            }
+        }*/
+
+    /*}*/
+
+    // Commented out for optimizations (Unused Event)
+    /*@EventHandler
+    public void onSfItemPickup(EntityPickupItemEvent event){
+        if(!(event.getEntity() instanceof Player)){
+            return;
+        }
+        Player player = (Player) event.getEntity();
+        ItemStack itemStack = event.getItem().getItemStack();
+        SlimefunItem sfItem = SlimefunItem.getByItem(itemStack);
+        if(sfItem instanceof Quiver) {
+            for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                ItemStack item = player.getInventory().getItem(i);
+
+                if(item != null && item.getType() == Material.CROSSBOW){
+                    itemStack.setType(Material.LEATHER);
+                }
+            }
+        }
+
+        if(itemStack.getType() == Material.CROSSBOW){
+            for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                ItemStack item2 = player.getInventory().getItem(i);
+                SlimefunItem slimefunItem = SlimefunItem.getByItem(item2);
+
+                if(item2 != null && slimefunItem instanceof Quiver){
+                    item2.setType(Material.LEATHER);
+                }
+            }
+
+        }
+
+    }*/
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onRightClick(PlayerInteractEvent event){
+
+        Player player = event.getPlayer();
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        int length = player.getInventory().getContents().length;
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            if (itemStack.getType() == Material.CROSSBOW) {
+                for (int i = 0; i < length; i++) {
+                    ItemStack itemStack1 = player.getInventory().getItem(i);
+                    SlimefunItem item = SlimefunItem.getByItem(itemStack1);
+
+                    if (item instanceof Quiver) {
+                        itemStack1.setType(Material.LEATHER);
+                    }
+
+                    if (item instanceof SpectralQuiver) {
+                        itemStack1.setType(Material.LEATHER);
+                    }
+
+                    if (item instanceof UpgradedQuiver) {
+                        itemStack1.setType(Material.LEATHER);
+                    }
+
+                    if (item instanceof UpgradedSpectralQuiver) {
+                        itemStack1.setType(Material.LEATHER);
+                    }
+
+                } // loop
+            } // crossbow
+        } // event
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK ||
+                event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+
+            if(itemStack.getType() == Material.LEATHER || itemStack.getType() == Material.ARROW || itemStack.getType() == Material.SPECTRAL_ARROW) {
+                for (int i = 0; i < length; i++) {
+                    SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+
+                    if (sfItem instanceof Quiver) {
+                        ((Quiver) sfItem).onRightClick(event);
+                    }
+
+                    if (sfItem instanceof SpectralQuiver) {
+                        ((SpectralQuiver) sfItem).onRightClick(event);
+                    }
+
+                    if (sfItem instanceof UpgradedQuiver) {
+                        ((UpgradedQuiver) sfItem).onRightClick(event);
+                    }
+
+                    if (sfItem instanceof UpgradedSpectralQuiver) {
+                        ((UpgradedSpectralQuiver) sfItem).onRightClick(event);
+                    }
+
+                } // loop
+            } // item type
+
+        } // event action
+
+    }
+
+    @EventHandler(priority = EventPriority.NORMAL)
+    public void onBowShoot(EntityShootBowEvent event){
+
+        if(event.getEntity() instanceof Player) {
+            Player player = (Player) event.getEntity();
+            if (player.getGameMode() != GameMode.CREATIVE) {
+                SlimefunItem sfItem = SlimefunItem.getByItem(event.getConsumable());
+
+                if (sfItem instanceof Quiver) {
+                    ((Quiver) sfItem).bowShoot(event);
+                }
+
+                if (sfItem instanceof SpectralQuiver) {
+                    ((SpectralQuiver) sfItem).bowShoot(event);
+                }
+
+                if (sfItem instanceof UpgradedQuiver) {
+                    ((UpgradedQuiver) sfItem).bowShoot(event);
+                }
+
+                if (sfItem instanceof UpgradedSpectralQuiver) {
+                    ((UpgradedSpectralQuiver) sfItem).bowShoot(event);
+                }
+
+            } // game mode
+        } // instanceof
+
+    }
+
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Quiver/Quiver.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Quiver/Quiver.java
@@ -1,0 +1,286 @@
+package ne.fnfal113.fnamplifications.Quiver;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.*;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Quiver extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+
+    public Quiver(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "arrows");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "arrowid");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    public void onRightClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        SlimefunItem sfCheck = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+        boolean instance = sfCheck instanceof Quiver;
+        ItemStack itemState = player.getInventory().getItemInMainHand();
+
+        List<String> lore = new ArrayList<>();
+
+        ItemMeta arrowMeta = itemState.getItemMeta();
+
+        if(arrowMeta == null){
+            return;
+        }
+        PersistentDataContainer arrows_Check = arrowMeta.getPersistentDataContainer();
+        int arrowsCheckPDC = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        boolean pdcCheck = arrowsCheckPDC != 0;
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.LEATHER) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.ARROW);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 128 Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW +  "State: Open Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+            }
+        }
+
+        if(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.ARROW) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.LEATHER);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 128 Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+
+            }
+        }
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+
+            if(itemState.getType() == Material.ARROW && !(instance)) {
+                for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                    SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+                    ItemStack item = player.getInventory().getItem(i);
+
+                    if (sfItem instanceof Quiver) {
+                        if (item != null && item.getAmount() == 1) {
+                            ItemStack itemStack = player.getInventory().getItem(i);
+                            if (itemStack == null) {
+                                return;
+                            }
+
+                            ItemMeta meta = itemStack.getItemMeta();
+                            if (meta == null) {
+                                return;
+                            }
+
+                            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+
+                            if (arrows != 128) {
+                                updateMetaArrows(itemStack, meta, key, key2, player);
+                                break;
+                            }
+
+                        } // null and amount check
+                    } // instance check
+
+                } // loop
+            }
+        } // event action
+
+    }
+
+    public void withdrawArrows(ItemStack itemState, ItemMeta arrowMeta, List<String> lore, Player player, PersistentDataContainer arrows_Check, NamespacedKey key){
+        int decrement = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int amount = decrement - 1;
+        arrows_Check.set(key, PersistentDataType.INTEGER, amount);
+        lore.add(0, "");
+        lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+        lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+        lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+        lore.add(4, "");
+        lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+        lore.add(6, ChatColor.YELLOW + "Size: 128 Arrows");
+        lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + amount);
+        if(amount == 0){
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+            itemState.setType(Material.LEATHER);
+        } else if (itemState.getType() == Material.ARROW){
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+        } else {
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+        }
+        arrowMeta.setLore(lore);
+        itemState.setItemMeta(arrowMeta);
+        player.getInventory().addItem(new ItemStack(Material.ARROW, 1));
+    }
+
+    public void updateMetaArrows(ItemStack item, ItemMeta meta, NamespacedKey key, NamespacedKey key2, Player player) {
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+        int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int random = ThreadLocalRandom.current().nextInt(1, 999999 + 1);
+        int increment = arrows + 1;
+
+        List<String> lore = new ArrayList<>();
+
+        if (increment != 129) {
+            arrow_Left.set(key, PersistentDataType.INTEGER, increment);
+            lore.add(0, "");
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+            lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+            lore.add(4, "");
+            lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+            lore.add(6, ChatColor.YELLOW + "Size: 128 Arrows");
+            lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + increment);
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+            meta.setLore(lore);
+            if(increment <= 2) {
+                meta.getPersistentDataContainer().set(key2, PersistentDataType.INTEGER, random);
+            }
+            item.setItemMeta(meta);
+            item.setType(Material.ARROW);
+            itemStack.setAmount(itemStack.getAmount() - 1);
+
+            if(increment == 128){
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lQuiver is full!"));
+            }
+
+        }
+
+    }
+
+    public void bowShoot(EntityShootBowEvent event){
+        ItemStack itemStack = event.getConsumable();
+        ItemStack itemStack2 = event.getBow();
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
+
+        if(itemStack == null){
+            return;
+        }
+
+        if(itemStack2 == null){
+            return;
+        }
+
+        if(slimefunItem instanceof Quiver) {
+            Player player = (Player) event.getEntity();
+            player.updateInventory();
+            event.setConsumeItem(false);
+            ItemMeta meta = itemStack.getItemMeta();
+            ItemMeta meta2 = itemStack2.getItemMeta();
+            NamespacedKey key = getStorageKey();
+
+            if(meta == null){
+                return;
+            }
+
+            if(meta2 == null){
+                return;
+            }
+
+            if(!(meta2.hasEnchant(Enchantment.ARROW_INFINITE))) {
+                PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+                int decrement = arrows - 1;
+
+                List<String> lore = new ArrayList<>();
+
+                if (decrement >= 0) {
+                    arrow_Left.set(key, PersistentDataType.INTEGER, decrement);
+                    lore.add(0, "");
+                    lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                    lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                    lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                    lore.add(4, "");
+                    lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                    lore.add(6, ChatColor.YELLOW + "Size: 128 Arrows");
+                    lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + decrement);
+                    lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+                    meta.setLore(lore);
+                    itemStack.setItemMeta(meta);
+
+                    if (decrement == 0) {
+                        itemStack.setType(Material.LEATHER);
+                        lore.set(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+                        meta.setLore(lore);
+                        itemStack.setItemMeta(meta);
+                    }
+
+                }
+            }
+
+        }
+
+    }
+
+    public static void setup() {
+        new Quiver(FNAmpItems.FN_MISC, FNAmpItems.FN_QUIVER, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.TIN_INGOT, 5), new ItemStack(Material.LEAD, 3), new SlimefunItemStack(SlimefunItems.COPPER_INGOT, 5),
+                new ItemStack(Material.STRING, 16), new ItemStack(Material.STICK, 24),  new ItemStack(Material.STRING, 16),
+                new SlimefunItemStack(SlimefunItems.TIN_INGOT, 5), new ItemStack(Material.LEATHER, 16), new SlimefunItemStack(SlimefunItems.COPPER_INGOT, 5)})
+                .register(plugin);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Quiver/SpectralQuiver.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Quiver/SpectralQuiver.java
@@ -1,0 +1,274 @@
+package ne.fnfal113.fnamplifications.Quiver;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class SpectralQuiver extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+
+    public SpectralQuiver(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "spectralarrows");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "spectralarrowid");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    public void onRightClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        SlimefunItem sfCheck = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+        boolean instance = sfCheck instanceof SpectralQuiver;
+        ItemStack itemState = player.getInventory().getItemInMainHand();
+
+        List<String> lore = new ArrayList<>();
+
+        ItemMeta arrowMeta = itemState.getItemMeta();
+
+        if(arrowMeta == null){
+            return;
+        }
+        PersistentDataContainer arrows_Check = arrowMeta.getPersistentDataContainer();
+        int arrowsCheckPDC = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        boolean pdcCheck = arrowsCheckPDC != 0;
+
+        if(event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_AIR) {
+            if (pdcCheck && instance && itemState.getType() == Material.LEATHER) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.SPECTRAL_ARROW);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 128 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8,  ChatColor.YELLOW + "State: Open Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+            }
+        }
+
+        if(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.SPECTRAL_ARROW) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.LEATHER);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 128 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+
+            }
+        }
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+
+            if(itemState.getType() == Material.SPECTRAL_ARROW && !(instance)) {
+                for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                    SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+                    ItemStack item = player.getInventory().getItem(i);
+
+                    if (sfItem instanceof SpectralQuiver) {
+                        if (item != null && item.getAmount() == 1) {
+                            ItemStack itemStack = player.getInventory().getItem(i);
+                            if (itemStack == null) {
+                                return;
+                            }
+
+                            ItemMeta meta = itemStack.getItemMeta();
+                            if (meta == null) {
+                                return;
+                            }
+
+                            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+
+                            if (arrows != 128) {
+                                updateMetaArrows(itemStack, meta, key, key2, player);
+                                break;
+                            }
+
+                        } // null and amount check
+                    } // instance check
+
+                } // loop
+            }
+        } // event action
+
+    }
+
+    public void withdrawArrows(ItemStack itemState, ItemMeta arrowMeta, List<String> lore, Player player, PersistentDataContainer arrows_Check, NamespacedKey key){
+        int decrement = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int amount = decrement - 1;
+        arrows_Check.set(key, PersistentDataType.INTEGER, amount);
+        lore.add(0, "");
+        lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+        lore.add(2, ChatColor.LIGHT_PURPLE + "right clicking spectral arrows or");
+        lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+        lore.add(4, "");
+        lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+        lore.add(6, ChatColor.YELLOW + "Size: 128 Spectral Arrows");
+        lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + amount);
+        if(amount == 0){
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+            itemState.setType(Material.LEATHER);
+        } else if (itemState.getType() == Material.SPECTRAL_ARROW){
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+        } else {
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+        }
+        arrowMeta.setLore(lore);
+        itemState.setItemMeta(arrowMeta);
+        player.getInventory().addItem(new ItemStack(Material.SPECTRAL_ARROW, 1));
+    }
+
+    public void updateMetaArrows(ItemStack item, ItemMeta meta, NamespacedKey key, NamespacedKey key2, Player player) {
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+        int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int random = ThreadLocalRandom.current().nextInt(1, 999999 + 1);
+        int increment = arrows + 1;
+
+        List<String> lore = new ArrayList<>();
+
+        if (increment != 129) {
+            arrow_Left.set(key, PersistentDataType.INTEGER, increment);
+            lore.add(0, "");
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "right clicking spectral arrows or");
+            lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+            lore.add(4, "");
+            lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+            lore.add(6, ChatColor.YELLOW + "Size: 128 Spectral Arrows");
+            lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + increment);
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+            meta.setLore(lore);
+            if(increment <= 2) {
+                meta.getPersistentDataContainer().set(key2, PersistentDataType.INTEGER, random);
+            }
+            item.setItemMeta(meta);
+            item.setType(Material.SPECTRAL_ARROW);
+            itemStack.setAmount(itemStack.getAmount() - 1);
+
+            if(increment == 128){
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lQuiver (Spectral) is full!"));
+            }
+
+        }
+
+    }
+
+    public void bowShoot(EntityShootBowEvent event){
+        ItemStack itemStack = event.getConsumable();
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
+
+        if(itemStack == null){
+            return;
+        }
+
+        if(slimefunItem instanceof SpectralQuiver) {
+            Player player = (Player) event.getEntity();
+            event.setConsumeItem(false);
+            player.updateInventory();
+            ItemMeta meta = itemStack.getItemMeta();
+            NamespacedKey key = getStorageKey();
+
+            if(meta == null){
+                return;
+            }
+
+            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+            int decrement = arrows - 1;
+
+            List<String> lore = new ArrayList<>();
+
+            if (decrement >= 0) {
+                arrow_Left.set(key, PersistentDataType.INTEGER, decrement);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 128 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + decrement);
+                lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+                meta.setLore(lore);
+                itemStack.setItemMeta(meta);
+
+                if (decrement == 0) {
+                    itemStack.setType(Material.LEATHER);
+                    lore.set(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+                    meta.setLore(lore);
+                    itemStack.setItemMeta(meta);
+                }
+            }
+
+        }
+
+    }
+
+    public static void setup() {
+        new SpectralQuiver(FNAmpItems.FN_MISC, FNAmpItems.FN_SPECTRAL_QUIVER, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.GOLD_4K, 3), new ItemStack(Material.LEAD, 3), new SlimefunItemStack(SlimefunItems.STEEL_INGOT, 3),
+                new ItemStack(Material.STRING, 24), new ItemStack(Material.STICK, 24),  new ItemStack(Material.STRING, 24),
+                new SlimefunItemStack(SlimefunItems.GOLD_4K, 3), new ItemStack(Material.LEATHER, 16), new SlimefunItemStack(SlimefunItems.STEEL_INGOT, 3)})
+                .register(plugin);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Quiver/UpgradedQuiver.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Quiver/UpgradedQuiver.java
@@ -1,0 +1,288 @@
+package ne.fnfal113.fnamplifications.Quiver;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class UpgradedQuiver extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+
+    public UpgradedQuiver(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "upgradedarrows");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "upgradedarrowid");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    public void onRightClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        SlimefunItem sfCheck = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+        boolean instance = sfCheck instanceof UpgradedQuiver;
+        ItemStack itemState = player.getInventory().getItemInMainHand();
+
+        List<String> lore = new ArrayList<>();
+
+        ItemMeta arrowMeta = itemState.getItemMeta();
+
+        if(arrowMeta == null){
+            return;
+        }
+        PersistentDataContainer arrows_Check = arrowMeta.getPersistentDataContainer();
+        int arrowsCheckPDC = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        boolean pdcCheck = arrowsCheckPDC != 0;
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.LEATHER) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.ARROW);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 192 Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+            }
+        }
+
+        if(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.ARROW) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.LEATHER);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 192 Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+
+            }
+        }
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+
+            if(itemState.getType() == Material.ARROW && !(instance)) {
+                for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                    SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+                    ItemStack item = player.getInventory().getItem(i);
+
+                    if (sfItem instanceof UpgradedQuiver) {
+                        if (item != null && item.getAmount() == 1) {
+                            ItemStack itemStack = player.getInventory().getItem(i);
+                            if (itemStack == null) {
+                                return;
+                            }
+
+                            ItemMeta meta = itemStack.getItemMeta();
+                            if (meta == null) {
+                                return;
+                            }
+
+                            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+
+                            if (arrows != 192) {
+                                updateMetaArrows(itemStack, meta, key, key2, player);
+                                break;
+                            }
+
+                        } // null and amount check
+                    } // instance check
+
+                } // loop
+            }
+        } // event action
+
+    }
+
+    public void withdrawArrows(ItemStack itemState, ItemMeta arrowMeta, List<String> lore, Player player, PersistentDataContainer arrows_Check, NamespacedKey key){
+        int decrement = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int amount = decrement - 1;
+        arrows_Check.set(key, PersistentDataType.INTEGER, amount);
+        lore.add(0, "");
+        lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+        lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+        lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+        lore.add(4, "");
+        lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+        lore.add(6, ChatColor.YELLOW + "Size: 192 Arrows");
+        lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + amount);
+        if(amount == 0){
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+            itemState.setType(Material.LEATHER);
+        } else if (itemState.getType() == Material.ARROW){
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+        } else {
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+        }
+        arrowMeta.setLore(lore);
+        itemState.setItemMeta(arrowMeta);
+        player.getInventory().addItem(new ItemStack(Material.ARROW, 1));
+    }
+
+    public void updateMetaArrows(ItemStack item, ItemMeta meta, NamespacedKey key, NamespacedKey key2, Player player) {
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+        int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int random = ThreadLocalRandom.current().nextInt(1, 999999 + 1);
+        int increment = arrows + 1;
+
+        List<String> lore = new ArrayList<>();
+
+        if(increment != 193) {
+            arrow_Left.set(key, PersistentDataType.INTEGER, increment);
+            lore.add(0, "");
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+            lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+            lore.add(4, "");
+            lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+            lore.add(6, ChatColor.YELLOW + "Size: 192 Arrows");
+            lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + increment);
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+            meta.setLore(lore);
+            if(increment <= 2) {
+                meta.getPersistentDataContainer().set(key2, PersistentDataType.INTEGER, random);
+            }
+            item.setItemMeta(meta);
+            item.setType(Material.ARROW);
+            itemStack.setAmount(itemStack.getAmount() - 1);
+
+            if (increment == 192){
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lUpgraded Quiver is full!"));
+            }
+
+        }
+
+    }
+
+    public void bowShoot(EntityShootBowEvent event){
+        ItemStack itemStack = event.getConsumable();
+        ItemStack itemStack2 = event.getBow();
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
+
+        if(itemStack == null){
+            return;
+        }
+
+        if(itemStack2 == null){
+            return;
+        }
+
+        if(slimefunItem instanceof UpgradedQuiver) {
+            Player player = (Player) event.getEntity();
+            event.setConsumeItem(false);
+            player.updateInventory();
+            ItemMeta meta = itemStack.getItemMeta();
+            ItemMeta meta2 = itemStack2.getItemMeta();
+            NamespacedKey key = getStorageKey();
+
+            if(meta == null){
+                return;
+            }
+
+            if(meta2 == null){
+                return;
+            }
+
+            if(!(meta2.hasEnchant(Enchantment.ARROW_INFINITE))) {
+                PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+                int decrement = arrows - 1;
+
+                List<String> lore = new ArrayList<>();
+
+                if (decrement >= 0) {
+                    arrow_Left.set(key, PersistentDataType.INTEGER, decrement);
+                    lore.add(0, "");
+                    lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver");
+                    lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking arrows or");
+                    lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                    lore.add(4, "");
+                    lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                    lore.add(6, ChatColor.YELLOW + "Size: 192 Arrows");
+                    lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + decrement);
+                    lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+                    meta.setLore(lore);
+                    itemStack.setItemMeta(meta);
+
+                    if (decrement == 0) {
+                        itemStack.setType(Material.LEATHER);
+                        lore.set(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+                        meta.setLore(lore);
+                        itemStack.setItemMeta(meta);
+                    }
+
+                }
+            }
+
+        }
+
+    }
+
+    public static void setup() {
+        new UpgradedQuiver(FNAmpItems.FN_MISC, FNAmpItems.FN_UPGRADED_QUIVER, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.LEAD_INGOT, 5), FNAmpItems.FN_UPGRADED_QUIVER, new SlimefunItemStack(SlimefunItems.BRONZE_INGOT, 5),
+                new ItemStack(Material.STRING, 32), new ItemStack(Material.STICK, 48),  new ItemStack(Material.STRING, 32),
+                new SlimefunItemStack(SlimefunItems.LEAD_INGOT, 5), new ItemStack(Material.LEATHER, 32), new SlimefunItemStack(SlimefunItems.BRONZE_INGOT, 5)})
+                .register(plugin);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Quiver/UpgradedSpectralQuiver.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Quiver/UpgradedSpectralQuiver.java
@@ -1,0 +1,274 @@
+package ne.fnfal113.fnamplifications.Quiver;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.event.block.Action;
+import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class UpgradedSpectralQuiver extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private final NamespacedKey defaultUsageKey;
+    private final NamespacedKey defaultUsageKey2;
+
+    public UpgradedSpectralQuiver(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "upgradedspectralarrows");
+        this.defaultUsageKey2 = new NamespacedKey(FNAmplifications.getInstance(), "upgradedspectralarrowid");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey2() {
+        return defaultUsageKey2;
+    }
+
+    public void onRightClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        NamespacedKey key = getStorageKey();
+        NamespacedKey key2 = getStorageKey2();
+        SlimefunItem sfCheck = SlimefunItem.getByItem(player.getInventory().getItemInMainHand());
+        boolean instance = sfCheck instanceof UpgradedSpectralQuiver;
+        ItemStack itemState = player.getInventory().getItemInMainHand();
+
+        List<String> lore = new ArrayList<>();
+
+        ItemMeta arrowMeta = itemState.getItemMeta();
+
+        if(arrowMeta == null){
+            return;
+        }
+        PersistentDataContainer arrows_Check = arrowMeta.getPersistentDataContainer();
+        int arrowsCheckPDC = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        boolean pdcCheck = arrowsCheckPDC != 0;
+
+        if(event.getAction() == Action.RIGHT_CLICK_BLOCK || event.getAction() == Action.RIGHT_CLICK_AIR) {
+            if (pdcCheck && instance && itemState.getType() == Material.LEATHER) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.SPECTRAL_ARROW);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 192 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8,  ChatColor.YELLOW + "State: Open Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+            }
+        }
+
+        if(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) {
+            if (pdcCheck && instance && itemState.getType() == Material.SPECTRAL_ARROW) {
+
+                if(player.isSneaking()) {
+                    withdrawArrows(itemState, arrowMeta, lore, player, arrows_Check, key);
+                    return;
+                }
+
+                itemState.setType(Material.LEATHER);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 192 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + arrowsCheckPDC);
+                lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+                arrowMeta.setLore(lore);
+                itemState.setItemMeta(arrowMeta);
+
+            }
+        }
+
+        if(event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) {
+
+            if(itemState.getType() == Material.SPECTRAL_ARROW && !(instance)) {
+                for (int i = 0; i < player.getInventory().getContents().length; i++) {
+                    SlimefunItem sfItem = SlimefunItem.getByItem(player.getInventory().getItem(i));
+                    ItemStack item = player.getInventory().getItem(i);
+
+                    if (sfItem instanceof UpgradedSpectralQuiver) {
+                        if (item != null && item.getAmount() == 1) {
+                            ItemStack itemStack = player.getInventory().getItem(i);
+                            if (itemStack == null) {
+                                return;
+                            }
+
+                            ItemMeta meta = itemStack.getItemMeta();
+                            if (meta == null) {
+                                return;
+                            }
+
+                            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+                            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+
+                            if (arrows != 192) {
+                                updateMetaArrows(itemStack, meta, key, key2, player);
+                                break;
+                            }
+
+                        } // null and amount check
+                    } // instance check
+
+                } // loop
+            }
+        } // event action
+
+    }
+
+    public void withdrawArrows(ItemStack itemState, ItemMeta arrowMeta, List<String> lore, Player player, PersistentDataContainer arrows_Check, NamespacedKey key){
+        int decrement = arrows_Check.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int amount = decrement - 1;
+        arrows_Check.set(key, PersistentDataType.INTEGER, amount);
+        lore.add(0, "");
+        lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+        lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking spectral arrows or");
+        lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+        lore.add(4, "");
+        lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+        lore.add(6, ChatColor.YELLOW + "Size: 192 Spectral Arrows");
+        lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + amount);
+        if(amount == 0){
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+            itemState.setType(Material.LEATHER);
+        } else if (itemState.getType() == Material.SPECTRAL_ARROW){
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+        } else {
+            lore.add(8, ChatColor.YELLOW + "State: Closed Quiver");
+        }
+        arrowMeta.setLore(lore);
+        itemState.setItemMeta(arrowMeta);
+        player.getInventory().addItem(new ItemStack(Material.SPECTRAL_ARROW, 1));
+    }
+
+    public void updateMetaArrows(ItemStack item, ItemMeta meta, NamespacedKey key, NamespacedKey key2, Player player) {
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+        int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+        int random = ThreadLocalRandom.current().nextInt(1, 999999 + 1);
+        int increment = arrows + 1;
+
+        List<String> lore = new ArrayList<>();
+
+        if (increment != 193) {
+            arrow_Left.set(key, PersistentDataType.INTEGER, increment);
+            lore.add(0, "");
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking spectral arrows or");
+            lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+            lore.add(4, "");
+            lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+            lore.add(6, ChatColor.YELLOW + "Size: 192 Spectral Arrows");
+            lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + increment);
+            lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+            meta.setLore(lore);
+            if(increment <= 2) {
+                meta.getPersistentDataContainer().set(key2, PersistentDataType.INTEGER, random);
+            }
+            item.setItemMeta(meta);
+            item.setType(Material.SPECTRAL_ARROW);
+            itemStack.setAmount(itemStack.getAmount() - 1);
+
+            if(increment == 192){
+                player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lUpgraded Quiver (Spectral) is full!"));
+            }
+
+        }
+
+    }
+
+    public void bowShoot(EntityShootBowEvent event){
+        ItemStack itemStack = event.getConsumable();
+        SlimefunItem slimefunItem = SlimefunItem.getByItem(itemStack);
+
+        if(itemStack == null){
+            return;
+        }
+
+        if(slimefunItem instanceof UpgradedSpectralQuiver) {
+            Player player = (Player) event.getEntity();
+            event.setConsumeItem(false);
+            player.updateInventory();
+            ItemMeta meta = itemStack.getItemMeta();
+            NamespacedKey key = getStorageKey();
+
+            if(meta == null){
+                return;
+            }
+
+            PersistentDataContainer arrow_Left = meta.getPersistentDataContainer();
+            int arrows = arrow_Left.getOrDefault(key, PersistentDataType.INTEGER, 0);
+            int decrement = arrows - 1;
+
+            List<String> lore = new ArrayList<>();
+
+            if (decrement >= 0) {
+                arrow_Left.set(key, PersistentDataType.INTEGER, decrement);
+                lore.add(0, "");
+                lore.add(1, ChatColor.LIGHT_PURPLE + "Store inside the quiver by");
+                lore.add(2, ChatColor.LIGHT_PURPLE + "by right clicking spectral arrows or");
+                lore.add(3, ChatColor.LIGHT_PURPLE + "shift click quiver to withdraw");
+                lore.add(4, "");
+                lore.add(5, ChatColor.YELLOW + "Left/Right click to change state");
+                lore.add(6, ChatColor.YELLOW + "Size: 192 Spectral Arrows");
+                lore.add(7, ChatColor.YELLOW + "Arrows: " + ChatColor.WHITE + decrement);
+                lore.add(8, ChatColor.YELLOW + "State: Open Quiver");
+                meta.setLore(lore);
+                itemStack.setItemMeta(meta);
+
+                if (decrement == 0) {
+                    itemStack.setType(Material.LEATHER);
+                    lore.set(8, ChatColor.YELLOW + "State: Closed Quiver (Empty)");
+                    meta.setLore(lore);
+                    itemStack.setItemMeta(meta);
+                }
+            }
+
+        }
+
+    }
+
+    public static void setup() {
+        new UpgradedSpectralQuiver(FNAmpItems.FN_MISC, FNAmpItems.FN_UPGRADED_SPECTRAL_QUIVER, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.GOLD_10K, 3), FNAmpItems.FN_SPECTRAL_QUIVER, new SlimefunItemStack(SlimefunItems.DAMASCUS_STEEL_INGOT, 3),
+                new ItemStack(Material.STRING, 48), new ItemStack(Material.STICK, 36),  new ItemStack(Material.STRING, 48),
+                new SlimefunItemStack(SlimefunItems.GOLD_10K, 3), new ItemStack(Material.LEATHER, 24), new SlimefunItemStack(SlimefunItems.DAMASCUS_STEEL_INGOT, 3)})
+                .register(plugin);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfInvisibility.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfInvisibility.java
@@ -32,7 +32,7 @@ public class StaffOfInvisibility extends SlimefunItem {
 
     private final NamespacedKey defaultUsageKey;
 
-    protected StaffOfInvisibility(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public StaffOfInvisibility(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
         this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "invistaff");

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfLocomotion.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfLocomotion.java
@@ -38,7 +38,7 @@ public class StaffOfLocomotion extends SlimefunItem {
 
     private final NamespacedKey defaultUsageKey2;
 
-    protected StaffOfLocomotion(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public StaffOfLocomotion(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
         this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "movestaff");

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfTeleportation.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfTeleportation.java
@@ -35,7 +35,7 @@ public class StaffOfTeleportation extends SlimefunItem {
 
     private final NamespacedKey defaultUsageKey;
 
-    protected StaffOfTeleportation(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public StaffOfTeleportation(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
         this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "tpstaff");

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -181,3 +181,10 @@ E-block-breaker3-tickRate: 2
 Staff-of-Locomotion: 10
 Staff-of-Invisibility: 10
 Staff-of-Teleportation: 10
+
+# FN Gears of Friction (Unbreakability)
+# Default is set to false (if set to true, will apply only on newly crafted gears)
+FN-Helmet-Unbreakable: false
+FN-Chestplate-Unbreakable: false
+FN-Leggings-Unbreakable: false
+FN-boots-Unbreakable: false


### PR DESCRIPTION
## Changes
- Added Quivers for bow which can store normal arrows and spectral arrows (crossbow not supported due to spigot api not having EntityLoadCrossbowEvent)
- Gears is now configurable in config.yml to become unbreakable or not (only applies to newly crafted gears)

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
