### PR TITLE
Added Staff of Stallion

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.8.4</version>
+    <version>2.8.5</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
@@ -421,6 +421,10 @@ public class ReturnConfValue {
         return config.getInt("Staff-of-Gravity");
     }
 
+    public int staffOfStallion() {
+        return config.getInt("Staff-of-Stallion");
+    }
+
     public boolean fnHelmetUnbreakable(){
         return config.getBoolean("FN-Helmet-Unbreakable");
     }

--- a/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Gears/FnBoots.java
@@ -178,7 +178,7 @@ public class FnBoots extends SlimefunItem {
             armor.setItemMeta(meta);
             levelUp(p);
         } else if(level == 6){
-            meta.addEnchant(Enchantment.FROST_WALKER, 3, true);
+            meta.addEnchant(Enchantment.DURABILITY, 3, true);
             armor.setItemMeta(meta);
             levelUp(p);
         } else if(level == 7){

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
@@ -144,6 +144,7 @@ public final class FNAmpItemSetup {
         StaffOfDeepFreeze.setup();
         StaffOfConfusion.setup();
         StaffOfGravitationalPull.setup();
+        StaffOfStallion.setup();
     }
 
     public void registerQuiver(){

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -1203,6 +1203,17 @@ public class FNAmpItems {
             "&eUses left: " + value.staffOfGravity()
     );
 
+    public static final SlimefunItemStack FN_STAFF_STALLION = new SlimefunItemStack(
+            "FN_STAFF_STALLION",
+            Material.BLAZE_ROD,
+            "&cStaff of Stallion",
+            "",
+            "&dSpawns a skeleton horse that is",
+            "&drideable until passenger dismount",
+            "",
+            "&eUses left: " + value.staffOfStallion()
+    );
+
     public static final SlimefunItemStack FN_QUIVER = new SlimefunItemStack(
             "FN_QUIVER",
             Material.LEATHER,

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
@@ -1,18 +1,23 @@
 package ne.fnfal113.fnamplifications.Staffs.Listener;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Staffs.*;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.SkeletonHorse;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.entity.AreaEffectCloudApplyEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.Objects;
@@ -112,6 +117,38 @@ public class StaffListener implements Listener {
                 ((StaffOfGravitationalPull) stick).onRightClick(e);
             }
         }
+
+        if (actionRight && e.getHand() == EquipmentSlot.HAND) {
+            if (stick instanceof StaffOfStallion) {
+                ((StaffOfStallion) stick).onRightClick(e);
+            }
+        }
+
+    }
+
+    @EventHandler
+    public void onPlayerDismount(VehicleExitEvent event){
+        if(event.getExited() instanceof Player){
+            if(event.getVehicle() instanceof SkeletonHorse){
+                SkeletonHorse skeletonHorse = (SkeletonHorse) event.getVehicle();
+                if(skeletonHorse.getCustomName() != null && !skeletonHorse.getPersistentDataContainer().isEmpty()) {
+                    if (skeletonHorse.getCustomName().equals("FN_SKELETON_HORSE")) {
+                        skeletonHorse.remove();
+                        skeletonHorse.getPersistentDataContainer().remove(new NamespacedKey(FNAmplifications.getInstance(), "Horsey"));
+                    }
+                }
+            } // instanceof SkeletonHorse
+        } // instanceof Player
+
+    }
+
+    @EventHandler
+    public void horseInventory(InventoryOpenEvent event){
+        if(event.getInventory().getHolder() instanceof SkeletonHorse) {
+            if (event.getView().getTitle().equals("FN_SKELETON_HORSE")) {
+                event.setCancelled(true);
+            } // check view/inventory title
+        } // check InventoryHolder
 
     }
 

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfStallion.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfStallion.java
@@ -1,0 +1,125 @@
+package ne.fnfal113.fnamplifications.Staffs;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.protection.Interaction;
+import ne.fnfal113.fnamplifications.ConfigValues.ReturnConfValue;
+import ne.fnfal113.fnamplifications.FNAmplifications;
+import ne.fnfal113.fnamplifications.Items.FNAmpItems;
+import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
+import org.bukkit.*;
+import org.bukkit.block.Block;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.SkeletonHorse;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.plugin.Plugin;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
+
+public class StaffOfStallion extends SlimefunItem {
+
+    private static final SlimefunAddon plugin = FNAmplifications.getInstance();
+
+    private static final ReturnConfValue value = new ReturnConfValue();
+
+    private final NamespacedKey defaultUsageKey;
+
+    public StaffOfStallion(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "stallionstaff");
+    }
+
+    protected @Nonnull
+    NamespacedKey getStorageKey() {
+        return defaultUsageKey;
+    }
+
+    public void onRightClick(PlayerInteractEvent event){
+        Player player = event.getPlayer();
+        ItemStack item = player.getInventory().getItemInMainHand();
+        NamespacedKey key = getStorageKey();
+        Block block = event.getPlayer().getTargetBlockExact(50);
+
+        if(block == null || item.getType() == Material.AIR){
+            return;
+        }
+
+        if (!Slimefun.getProtectionManager().hasPermission(
+                Bukkit.getOfflinePlayer(player.getUniqueId()),
+                block,
+                Interaction.BREAK_BLOCK)
+        ) {
+            player.sendMessage(ChatColor.DARK_RED + "You don't have permission to cast stallion there!");
+            return;
+        }
+
+        if(item.getItemMeta() == null){
+            return;
+        }
+
+        ItemMeta meta = item.getItemMeta();
+
+        updateMeta(item, meta, key, player);
+
+        SkeletonHorse skeletonHorse = (SkeletonHorse) player.getWorld().spawnEntity(player.getLocation() , EntityType.SKELETON_HORSE);
+        skeletonHorse.setAdult();
+        skeletonHorse.setTamed(true);
+        skeletonHorse.setCustomName("FN_SKELETON_HORSE");
+        skeletonHorse.setCustomNameVisible(false);
+        skeletonHorse.getPersistentDataContainer().set(new NamespacedKey((Plugin) plugin, "Horsey"), PersistentDataType.INTEGER, new Random().nextInt(9999));
+        skeletonHorse.setOwner(player);
+        skeletonHorse.getInventory().setSaddle(new ItemStack(Material.SADDLE));
+        skeletonHorse.addPassenger(player);
+
+        Objects.requireNonNull(player.getLocation().getWorld()).playSound(player.getLocation(), Sound.ENTITY_ILLUSIONER_CAST_SPELL, 1, 1);
+
+    }
+
+    public void updateMeta(ItemStack item, ItemMeta meta, NamespacedKey key, Player player){
+        PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfStallion());
+        int decrement = uses_Left - 1;
+
+        List<String> lore = new ArrayList<>();
+
+        if(decrement > 0) {
+            max_Uses.set(key, PersistentDataType.INTEGER, decrement);
+            lore.add(0, "");
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Spawns a skeleton horse that is");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "rideable until passenger dismount");
+            lore.add(3, "");
+            lore.add(4, ChatColor.YELLOW + "Uses left: " + decrement);
+            meta.setLore(lore);
+            item.setItemMeta(meta);
+        } else {
+            player.getInventory().setItemInMainHand(null);
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lStallion staff has reached max uses!"));
+            player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1 ,1);
+        }
+
+
+    }
+
+    public static void setup(){
+        new StaffOfStallion(FNAmpItems.FN_STAFFS, FNAmpItems.FN_STAFF_STALLION, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 32), new ItemStack(Material.SADDLE), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 32),
+                SlimefunItems.ESSENCE_OF_AFTERLIFE, new ItemStack(Material.BLAZE_ROD),  SlimefunItems.ESSENCE_OF_AFTERLIFE,
+                new ItemStack(Material.BONE, 32), SlimefunItems.MAGIC_SUGAR, new ItemStack(Material.BONE, 32)})
+                .register(plugin);
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -185,6 +185,7 @@ Staff-of-HellFire: 10
 Staff-of-DeepFreeze: 10
 Staff-of-Confusion: 10
 Staff-of-Gravity: 10
+Staff-of-Stallion: 10
 
 # FN Gears of Friction (Unbreakability)
 # Default is set to false (if set to true, will apply only on newly crafted gears)


### PR DESCRIPTION
## Changes
- Added Staff of Stallion, spawns a portable skeleton horse that is rideable until passenger dismount. Right clicking the staff will add you as passenger to the skeleton horse already.
- FN Gears Boots level 6 enchantment reward frost walker changed to durability 3 enchantment

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
