### PR TITLE
Added Staff of Force (Force Staff)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>2.8.5</version>
+    <version>2.8.6</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/ConfigValues/ReturnConfValue.java
@@ -425,6 +425,10 @@ public class ReturnConfValue {
         return config.getInt("Staff-of-Stallion");
     }
 
+    public int staffOfForce() {
+        return config.getInt("Staff-of-Force");
+    }
+
     public boolean fnHelmetUnbreakable(){
         return config.getBoolean("FN-Helmet-Unbreakable");
     }

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItemSetup.java
@@ -145,6 +145,7 @@ public final class FNAmpItemSetup {
         StaffOfConfusion.setup();
         StaffOfGravitationalPull.setup();
         StaffOfStallion.setup();
+        StaffOfForce.setup();
     }
 
     public void registerQuiver(){

--- a/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Items/FNAmpItems.java
@@ -1214,6 +1214,19 @@ public class FNAmpItems {
             "&eUses left: " + value.staffOfStallion()
     );
 
+    public static final SlimefunItemStack FN_STAFF_FORCE = new SlimefunItemStack(
+            "FN_STAFF_FORCE",
+            Material.BLAZE_ROD,
+            "&cStaff of Force",
+            "",
+            "&dRight click to spawn a cloud of effect",
+            "&dthat gives a force push forward or",
+            "&dshift-right-click to spawn a different cloud",
+            "&dof effect that gives a backward force",
+            "",
+            "&eUses left: " + value.staffOfForce()
+    );
+
     public static final SlimefunItemStack FN_QUIVER = new SlimefunItemStack(
             "FN_QUIVER",
             Material.LEATHER,

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/Listener/StaffListener.java
@@ -3,10 +3,7 @@ package ne.fnfal113.fnamplifications.Staffs.Listener;
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.Staffs.*;
-import org.bukkit.ChatColor;
-import org.bukkit.Location;
-import org.bukkit.NamespacedKey;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.SkeletonHorse;
@@ -21,7 +18,7 @@ import org.bukkit.event.vehicle.VehicleExitEvent;
 import org.bukkit.inventory.EquipmentSlot;
 
 import java.util.Objects;
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class StaffListener implements Listener {
 
@@ -42,10 +39,9 @@ public class StaffListener implements Listener {
 
         if (Objects.equals(event.getEntity().getCustomName(), "FN_CONFUSION")){
             for(LivingEntity entity : event.getAffectedEntities()){
-                Random random = new Random();
                 World world = entity.getWorld();
-                int pitch = random.nextInt(180 + 1 + 180) - 180;
-                int yaw = random.nextInt(180 + 1 + 180) - 180;
+                int pitch = ThreadLocalRandom.current().nextInt(180 + 1 + 180) - 180;
+                int yaw = ThreadLocalRandom.current().nextInt(180 + 1 + 180) - 180;
                 Location loc = new Location(world, entity.getLocation().getX(),
                         entity.getLocation().getY(),
                         entity.getLocation().getZ(), pitch, yaw);
@@ -56,6 +52,18 @@ public class StaffListener implements Listener {
         if (Objects.equals(event.getEntity().getCustomName(), "FN_GRAVITY")){
             for(LivingEntity entity : event.getAffectedEntities()){
                 entity.setVelocity(entity.getVelocity().clone().add(event.getEntity().getLocation().clone().toVector().subtract(entity.getLocation().clone().toVector()).multiply(0.800)));
+            }
+        }
+
+        if (Objects.equals(event.getEntity().getCustomName(), "FN_FORCE")){
+            for(LivingEntity entity : event.getAffectedEntities()){
+               entity.setVelocity(entity.getLocation().clone().getDirection().multiply(8).setY(0));
+            }
+        }
+
+        if (Objects.equals(event.getEntity().getCustomName(), "FN_BACKWARD_FORCE")){
+            for(LivingEntity entity : event.getAffectedEntities()){
+                entity.setVelocity(entity.getLocation().clone().getDirection().multiply(-8).setY(0));
             }
         }
 
@@ -121,6 +129,12 @@ public class StaffListener implements Listener {
         if (actionRight && e.getHand() == EquipmentSlot.HAND) {
             if (stick instanceof StaffOfStallion) {
                 ((StaffOfStallion) stick).onRightClick(e);
+            }
+        }
+
+        if (actionRight && e.getHand() == EquipmentSlot.HAND) {
+            if (stick instanceof StaffOfForce) {
+                ((StaffOfForce) stick).onRightClick(e);
             }
         }
 

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfConfusion.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfConfusion.java
@@ -53,7 +53,7 @@ public class StaffOfConfusion extends SlimefunItem {
         Player player = event.getPlayer();
         ItemStack item = player.getInventory().getItemInMainHand();
         NamespacedKey key = getStorageKey();
-        Block block = event.getPlayer().getTargetBlockExact(7);
+        Block block = event.getPlayer().getTargetBlockExact(50);
 
         if(block == null || item.getType() == Material.AIR){
             return;

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfForce.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfForce.java
@@ -14,7 +14,9 @@ import ne.fnfal113.fnamplifications.Items.FNAmpItems;
 import ne.fnfal113.fnamplifications.Multiblock.FnAssemblyStation;
 import org.bukkit.*;
 import org.bukkit.block.Block;
-import org.bukkit.entity.*;
+import org.bukkit.entity.AreaEffectCloud;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -28,7 +30,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class StaffOfDeepFreeze extends SlimefunItem {
+public class StaffOfForce extends SlimefunItem {
 
     private static final SlimefunAddon plugin = FNAmplifications.getInstance();
 
@@ -36,10 +38,10 @@ public class StaffOfDeepFreeze extends SlimefunItem {
 
     private final NamespacedKey defaultUsageKey;
 
-    public StaffOfDeepFreeze(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    public StaffOfForce(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe);
 
-        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "deepfreezestaff");
+        this.defaultUsageKey = new NamespacedKey(FNAmplifications.getInstance(), "forcestaff");
     }
 
     protected @Nonnull
@@ -62,7 +64,7 @@ public class StaffOfDeepFreeze extends SlimefunItem {
                 block,
                 Interaction.BREAK_BLOCK)
         ) {
-            player.sendMessage(ChatColor.DARK_RED + "You don't have permission to cast deep-freeze there!");
+            player.sendMessage(ChatColor.DARK_RED + "You don't have permission to cast force cloud there!");
             return;
         }
 
@@ -74,34 +76,25 @@ public class StaffOfDeepFreeze extends SlimefunItem {
 
         updateMeta(item, meta, key, player);
 
-        AreaEffectCloud effectCloud = (AreaEffectCloud) player.getWorld().spawnEntity(block.getLocation().add(0.5, 1, 0.5) , EntityType.AREA_EFFECT_CLOUD);
-        effectCloud.setParticle(Particle.SNOWFLAKE);
-        effectCloud.setDuration(160);
-        effectCloud.setRadius(2.85F);
-        effectCloud.setCustomName("FN_DEEP_FREEZE");
-        effectCloud.setCustomNameVisible(false);
-        effectCloud.addCustomEffect(new PotionEffect(PotionEffectType.GLOWING, 0, 0, false, false, false), true);
-
-        // Commented out in favor of AreaCloudEffectApply Event
-        /*World world = player.getWorld();
-        AtomicInteger i = new AtomicInteger(8);
-        taskID = Bukkit.getScheduler().runTaskTimer(FNAmplifications.getInstance(), () -> {
-            for (Entity e : world.getNearbyEntities(effectCloud.getLocation(), 2.85F, 2, 2.85F)) {
-
-                if (e instanceof LivingEntity) {
-                    if (e.getLocation().distance(effectCloud.getLocation()) <= 2.85F) {
-                        e.setFreezeTicks(210);
-                    }
-
-                }
-            }
-
-            if (i.get() == 0) {
-                taskID.cancel();
-            }
-            i.getAndDecrement();
-
-        }, 0, 20L);*/
+        if(player.isSneaking()) {
+            AreaEffectCloud effectCloudBack = (AreaEffectCloud) player.getWorld().spawnEntity(block.getLocation().add(0.5, 1, 0.5), EntityType.AREA_EFFECT_CLOUD);
+            effectCloudBack.setParticle(Particle.END_ROD);
+            effectCloudBack.setDuration(160);
+            effectCloudBack.setRadius(2.85F);
+            effectCloudBack.setCustomName("FN_BACKWARD_FORCE");
+            effectCloudBack.setCustomNameVisible(false);
+            effectCloudBack.addCustomEffect(new PotionEffect(PotionEffectType.GLOWING, 0, 0, false, false, false), true);
+            player.sendMessage(ChatColor.RED  + "You spawned a cloud effect with backward force");
+        } else {
+            AreaEffectCloud effectCloudForward = (AreaEffectCloud) player.getWorld().spawnEntity(block.getLocation().add(0.5, 1, 0.5), EntityType.AREA_EFFECT_CLOUD);
+            effectCloudForward.setParticle(Particle.ELECTRIC_SPARK);
+            effectCloudForward.setDuration(160);
+            effectCloudForward.setRadius(2.85F);
+            effectCloudForward.setCustomName("FN_FORCE");
+            effectCloudForward.setCustomNameVisible(false);
+            effectCloudForward.addCustomEffect(new PotionEffect(PotionEffectType.GLOWING, 0, 0, false, false, false), true);
+            player.sendMessage(ChatColor.GREEN + "You spawned a cloud effect with forward force");
+        }
 
         Objects.requireNonNull(player.getLocation().getWorld()).playSound(player.getLocation(), Sound.ENTITY_ILLUSIONER_CAST_SPELL, 1, 1);
 
@@ -109,7 +102,7 @@ public class StaffOfDeepFreeze extends SlimefunItem {
 
     public void updateMeta(ItemStack item, ItemMeta meta, NamespacedKey key, Player player){
         PersistentDataContainer max_Uses = meta.getPersistentDataContainer();
-        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfDeepFreeze());
+        int uses_Left = max_Uses.getOrDefault(key, PersistentDataType.INTEGER, value.staffOfForce());
         int decrement = uses_Left - 1;
 
         List<String> lore = new ArrayList<>();
@@ -117,16 +110,17 @@ public class StaffOfDeepFreeze extends SlimefunItem {
         if(decrement > 0) {
             max_Uses.set(key, PersistentDataType.INTEGER, decrement);
             lore.add(0, "");
-            lore.add(1, ChatColor.LIGHT_PURPLE + "Spawn an area of effect cloud where");
-            lore.add(2, ChatColor.LIGHT_PURPLE + "entities are being slowed by the freezing");
-            lore.add(3, ChatColor.LIGHT_PURPLE + "cold if inside the radius for 8 seconds");
-            lore.add(4, "");
-            lore.add(5, ChatColor.YELLOW + "Uses left: " + decrement);
+            lore.add(1, ChatColor.LIGHT_PURPLE + "Right click to spawn a cloud of effect");
+            lore.add(2, ChatColor.LIGHT_PURPLE + "that gives a force push forward or");
+            lore.add(3, ChatColor.LIGHT_PURPLE + "shift-right-click to spawn a different cloud");
+            lore.add(4, ChatColor.LIGHT_PURPLE + "of effect that gives a backward force");
+            lore.add(5, "");
+            lore.add(6, ChatColor.YELLOW + "Uses left: " + decrement);
             meta.setLore(lore);
             item.setItemMeta(meta);
         } else {
             player.getInventory().setItemInMainHand(null);
-            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lDeep-Freeze staff has reached max uses!"));
+            player.sendMessage(ChatColor.translateAlternateColorCodes('&', "&d&lForce staff has reached max uses!"));
             player.playSound(player.getLocation(), Sound.ENTITY_ITEM_BREAK, 1 ,1);
         }
 
@@ -134,10 +128,10 @@ public class StaffOfDeepFreeze extends SlimefunItem {
     }
 
     public static void setup(){
-        new StaffOfDeepFreeze(FNAmpItems.FN_STAFFS, FNAmpItems.FN_STAFF_DEEPFREEZE, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
-                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 8), new ItemStack(Material.LINGERING_POTION), new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 8),
-                SlimefunItems.MAGICAL_BOOK_COVER, new ItemStack(Material.BLAZE_ROD), SlimefunItems.MAGICAL_BOOK_COVER,
-                new SlimefunItemStack(SlimefunItems.WATER_RUNE, 3), SlimefunItems.MAGIC_SUGAR, new SlimefunItemStack(SlimefunItems.AIR_RUNE, 3)})
+        new StaffOfForce(FNAmpItems.FN_STAFFS, FNAmpItems.FN_STAFF_FORCE, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
+                new SlimefunItemStack(SlimefunItems.MAGIC_LUMP_3, 24), new ItemStack(Material.FEATHER, 12), new SlimefunItemStack(SlimefunItems.ENDER_LUMP_3, 24),
+                new SlimefunItemStack(SlimefunItems.AIR_RUNE, 3), new ItemStack(Material.BLAZE_ROD),  new SlimefunItemStack(SlimefunItems.AIR_RUNE, 3),
+                new ItemStack(Material.BLAZE_POWDER, 12), SlimefunItems.MAGIC_SUGAR, new ItemStack(Material.BLAZE_POWDER, 12)})
                 .register(plugin);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfGravitationalPull.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfGravitationalPull.java
@@ -53,7 +53,7 @@ public class StaffOfGravitationalPull extends SlimefunItem {
         Player player = event.getPlayer();
         ItemStack item = player.getInventory().getItemInMainHand();
         NamespacedKey key = getStorageKey();
-        Block block = event.getPlayer().getTargetBlockExact(7);
+        Block block = event.getPlayer().getTargetBlockExact(50);
 
         if(block == null || item.getType() == Material.AIR){
             return;

--- a/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfHellFire.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/Staffs/StaffOfHellFire.java
@@ -51,7 +51,7 @@ public class StaffOfHellFire extends SlimefunItem {
         Player player = event.getPlayer();
         ItemStack item = player.getInventory().getItemInMainHand();
         NamespacedKey key = getStorageKey();
-        Block block = event.getPlayer().getTargetBlockExact(7);
+        Block block = event.getPlayer().getTargetBlockExact(50);
 
         if(block == null || item.getType() == Material.AIR){
             return;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -186,6 +186,7 @@ Staff-of-DeepFreeze: 10
 Staff-of-Confusion: 10
 Staff-of-Gravity: 10
 Staff-of-Stallion: 10
+Staff-of-Force: 10
 
 # FN Gears of Friction (Unbreakability)
 # Default is set to false (if set to true, will apply only on newly crafted gears)


### PR DESCRIPTION
## Changes
- Added Staff of Force (Force Staff)
- Better staff confusion random number generation for pitch and yaw (less overhead)
- Increased the casting range for the Area of Effect Staffs from 7 blocks to 50 blocks (as long as the target block is not air, it can be casted)

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [x] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
