### PR TITLE
gem config chance fix and config manager changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>3.2.7-UNOFFICIAL</version>
+    <version>3.2.8-UNOFFICIAL</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>
@@ -110,7 +110,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>1.18.24</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/ne/fnfal113/fnamplifications/config/ConfigManager.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/config/ConfigManager.java
@@ -129,23 +129,23 @@ public class ConfigManager {
             return false;
         }
 
-        if (!getCustomConfig().isConfigurationSection(itemNameSection) && autoUpdateFile.contains(fileName)) {
+        if(autoUpdate){
+            // add newly created or missing settings and sections to the config
+            // does not run by default unless auto update is set to true then it will add missing entries
+            if(!getCustomConfig().isConfigurationSection(itemNameSection)){
+                getCustomConfig().createSection(itemNameSection).set(settings, val);
+            } else if (!getCustomConfig().getConfigurationSection(itemNameSection).getKeys(false).contains(settings)) {
+                getCustomConfig().getConfigurationSection(itemNameSection).set(settings, val);
+            }
+
+            autoUpdateFile.remove(fileName);
+        } else if (!getCustomConfig().isConfigurationSection(itemNameSection) && autoUpdateFile.contains(fileName)) {
             // create a config section if not exist and file name is in the auto update list
             // runs by default if the file is newly created and will add entries
             getCustomConfig().createSection(itemNameSection).set(settings, val);
         } else if (getCustomConfig().isConfigurationSection(itemNameSection) && autoUpdateFile.contains(fileName)) {
             // create settings if the config section exist and file name is in the auto update list
             // runs by default if the file is newly created and will add entries
-            if (!getCustomConfig().getConfigurationSection(itemNameSection).getKeys(false).contains(settings)) {
-                getCustomConfig().getConfigurationSection(itemNameSection).set(settings, val);
-            }
-        } else if(autoUpdateFile.contains(fileName) && autoUpdate){
-            // if the file name is in the auto update list, add newly created or missing settings and sections to the config
-            // does not run by default if the file is not newly created unless auto update is set to true then it will add missing entries
-            if(!getCustomConfig().isConfigurationSection(itemNameSection)){
-                getCustomConfig().createSection(itemNameSection).set(settings, val);
-            }
-
             if (!getCustomConfig().getConfigurationSection(itemNameSection).getKeys(false).contains(settings)) {
                 getCustomConfig().getConfigurationSection(itemNameSection).set(settings, val);
             }

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/abstracts/AbstractGem.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/abstracts/AbstractGem.java
@@ -42,7 +42,7 @@ public abstract class AbstractGem extends SlimefunItem implements GemHandler {
     @SneakyThrows
     public void initializeSettings(int defaultChance){
         if(defaultChance != 0) {
-            setConfigChanceValues(chance);
+            setConfigChanceValues(defaultChance);
             setConfigWorldSettings();
             Utils.upgradeGemLore(this.getItem(), this.getItem().getItemMeta(), this.getId(),
                     "chance", "%", "&e", "%", 4);


### PR DESCRIPTION
config manager now auto updates per missing sections or settings if autoUpdate parameter is set to true

## Changes
- fixed 0 chance when a newly created gem-settings.yml file is initialized
- config manager auto update per section or settings

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
