### PR TITLE
mat gen, gems and block rotator updates

### DIFF
--- a/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/FNAmplifications.java
@@ -13,6 +13,7 @@ import ne.fnfal113.fnamplifications.gems.listener.GemListener;
 import ne.fnfal113.fnamplifications.gems.listener.GemUnbinderListener;
 import ne.fnfal113.fnamplifications.integrations.VaultIntegration;
 import ne.fnfal113.fnamplifications.machines.listener.JukeBoxClickListener;
+import ne.fnfal113.fnamplifications.materialgenerators.listener.UpgradesListener;
 import ne.fnfal113.fnamplifications.mysteriousitems.listener.MysteryStickListener;
 import ne.fnfal113.fnamplifications.quivers.listener.QuiverListener;
 import ne.fnfal113.fnamplifications.staffs.listener.StaffListener;
@@ -92,6 +93,7 @@ public final class FNAmplifications extends JavaPlugin implements SlimefunAddon 
         getServer().getPluginManager().registerEvents(new ThrowableItemListener(), this);
         getServer().getPluginManager().registerEvents(new JukeBoxClickListener(), this);
         getServer().getPluginManager().registerEvents(new GemUnbinderListener(), this);
+        getServer().getPluginManager().registerEvents(new UpgradesListener(), this);
     }
 
     @Nonnull

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/implementation/RegisterGems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/implementation/RegisterGems.java
@@ -13,6 +13,7 @@ import ne.fnfal113.fnamplifications.gems.unbinder.FlawlessUnbindGem;
 import ne.fnfal113.fnamplifications.gems.unbinder.PreciousUnbindGem;
 import ne.fnfal113.fnamplifications.items.FNAmpItems;
 import ne.fnfal113.fnamplifications.multiblocks.FnGemAltar;
+import ne.fnfal113.fnamplifications.multiblocks.FnGemDowngrader;
 import ne.fnfal113.fnamplifications.multiblocks.FnGemUpgrader;
 import ne.fnfal113.fnamplifications.utils.PotionBuilder;
 import org.bukkit.Material;
@@ -27,6 +28,13 @@ public class RegisterGems {
             "",
             "&eSame gem type and must",
             "&ebe same level or tier"
+    );
+
+    private static final CustomItemStack anyUpgradedGem = new CustomItemStack(
+            Material.EMERALD,
+            "&dAny Upgraded Gem",
+            "",
+            "&eTier 2 to 4 gem"
     );
 
     public static void setup(SlimefunAddon instance){
@@ -276,6 +284,12 @@ public class RegisterGems {
                     anyUpgradeableGem.clone(), null, anyUpgradeableGem.clone(),
                     null, FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING, null,
                     anyUpgradeableGem.clone(), null, anyUpgradeableGem.clone()})
+                .register(instance);
+
+        new SlimefunItem(FNAmpItems.FN_GEMS, FNAmpItems.FN_GEM_DOWNGRADES_DISPLAY_ITEM, FnGemDowngrader.RECIPE_TYPE, new ItemStack[]{
+                FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING, null, FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING,
+                null, anyUpgradedGem.clone(), null,
+                FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING, null, FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING})
                 .register(instance);
 
     }

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/implementation/ThrowWeaponTask.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/implementation/ThrowWeaponTask.java
@@ -10,8 +10,8 @@ import org.bukkit.Material;
 import org.bukkit.Sound;
 import org.bukkit.Tag;
 import org.bukkit.entity.ArmorStand;
-import org.bukkit.entity.Entity;
 import org.bukkit.entity.Damageable;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -40,7 +40,7 @@ public class ThrowWeaponTask extends BukkitRunnable {
     @Getter
     private final boolean isTriWeapon;
     @Getter
-    private final boolean returnWeapon;
+    private final boolean isRetaliated;
     @Getter
     private final ReturnWeaponTask returnWeaponTask;
 
@@ -52,12 +52,12 @@ public class ThrowWeaponTask extends BukkitRunnable {
        this(player, itemStack, rotateWeapon, isTriWeapon, returnWeapon, new Vector(0, 0, 0));
     }
 
-    public ThrowWeaponTask(Player player, ItemStack itemStack, boolean rotateWeapon, boolean isTriWeapon, boolean returnWeapon, Vector vector){
+    public ThrowWeaponTask(Player player, ItemStack itemStack, boolean rotateWeapon, boolean isTriWeapon, boolean isRetaliated, Vector vector){
         this.player = player;
         this.itemStack = itemStack;
         this.rotateWeapon = rotateWeapon;
         this.isTriWeapon = isTriWeapon;
-        this.returnWeapon = returnWeapon;
+        this.isRetaliated = isRetaliated;
         this.vector = vector;
         this.armorStand = spawnArmorstand(player, itemStack);
         this.returnWeaponTask = new ReturnWeaponTask(getItemStack(), getArmorStand(), getPlayer());
@@ -104,14 +104,14 @@ public class ThrowWeaponTask extends BukkitRunnable {
 
         // check if the raytrace result has a block within the max distance
         // if it hits a block, the weapon is either returned or dropped
-        if(result != null && Objects.requireNonNull(result.getHitBlock()).getType() != Material.GRASS && !Tag.FLOWERS.isTagged(result.getHitBlock().getType())){
-            if(isReturnWeapon()) {
-                returnWeapon();
-
+        if(result != null &&
+                Objects.requireNonNull(result.getHitBlock()).getType() != Material.GRASS &&
+                    !Tag.FLOWERS.isTagged(result.getHitBlock().getType())){
+            if(shouldReturnWeapon(false)) {
                 return;
             }
 
-            dropWeaponTask(getArmorStand(), getPlayer(), getItemStack().clone());
+            dropWeapon();
             return;
         }
 
@@ -129,14 +129,12 @@ public class ThrowWeaponTask extends BukkitRunnable {
                 }
             }
 
-            if(isReturnWeapon() && !isTriWeapon()) {
-                returnWeapon();
-
+            if(shouldReturnWeapon(true)) {
                 return;
             }
 
             if(!isTriWeapon()) {
-                dropWeaponTask(getArmorStand(), getPlayer(), getItemStack().clone());
+                dropWeapon();
 
                 return;
             }
@@ -146,22 +144,34 @@ public class ThrowWeaponTask extends BukkitRunnable {
         if(getArmorStand().getLocation().distanceSquared(getPlayer().getLocation()) > 3600){
             getPlayer().sendMessage(Utils.colorTranslator("&eYour weapon has reached the max distance of 60 blocks!"));
 
-            dropWeaponTask(getArmorStand(), getPlayer(), getItemStack().clone());
+            if(shouldReturnWeapon(false)) {
+                return;
+            }
+            dropWeapon();
         }
     }
 
-    public void dropWeaponTask(ArmorStand as, Player player, ItemStack itemStack){
-        Item droppedItem = as.getWorld().dropItem(as.getLocation(), itemStack.clone());
-        Location locInfo = droppedItem.getLocation();
+    public boolean shouldReturnWeapon(boolean entityHit){
+        if(!isRetaliated() || (isTriWeapon() && entityHit)) {
+            return false;
+        }
+        returnWeapon();
 
-        droppedItem.setOwner(player.getUniqueId()); // only the player who threw can pick up the weapon
-        droppedItem.setGlowing(true);
+        return true;
+    }
 
-        as.remove();
-
+    public void dropWeapon(){
         this.cancel();
 
-        player.sendMessage(Utils.colorTranslator("&6Weapon dropped near at " +
+        Item droppedItem = getArmorStand().getWorld().dropItem(getArmorStand().getLocation(), getItemStack().clone());
+        Location locInfo = droppedItem.getLocation();
+
+        droppedItem.setOwner(getPlayer().getUniqueId()); // only the player who threw can pick up the weapon
+        droppedItem.setGlowing(true);
+
+        getArmorStand().remove();
+
+        getPlayer().sendMessage(Utils.colorTranslator("&6Weapon dropped near at " +
                 "x: " + (int) locInfo.getX() + ", " +
                 "y: " + (int) locInfo.getY() + ", " +
                 "z: " + (int) locInfo.getZ()));

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/listener/GemListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/listener/GemListener.java
@@ -62,6 +62,8 @@ public class GemListener implements Listener {
                     SlimefunItem item = getSfItem(key, pdc);
 
                     if(item instanceof AbstractGem) {
+                        // consumer requires an instance of the class that
+                        // extends a sub-interface of the gem handler interface
                         AbstractGem gem = (AbstractGem) item;
 
                         if(clazz.isInstance(gem)) {

--- a/src/main/java/ne/fnfal113/fnamplifications/items/FNAmpItemSetup.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/items/FNAmpItemSetup.java
@@ -6,10 +6,11 @@ import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.gears.implementation.RegisterGears;
 import ne.fnfal113.fnamplifications.gems.implementation.RegisterGems;
 import ne.fnfal113.fnamplifications.machines.implementation.RegisterMachines;
-import ne.fnfal113.fnamplifications.materialgenerators.FNMaterialGenerators;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.RegisterMaterialGeneratorUpgrades;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.RegisterMaterialGenerators;
 import ne.fnfal113.fnamplifications.multiblocks.*;
 import ne.fnfal113.fnamplifications.mysteriousitems.implementation.RegisterSticks;
-import ne.fnfal113.fnamplifications.powergenerators.FNPowerGenerators;
+import ne.fnfal113.fnamplifications.powergenerators.implementation.RegisterPowerGenerators;
 import ne.fnfal113.fnamplifications.quivers.implementations.RegisterQuiver;
 import ne.fnfal113.fnamplifications.staffs.implementations.RegisterStaffs;
 import ne.fnfal113.fnamplifications.tools.implementation.RegisterTools;
@@ -29,11 +30,14 @@ public final class FNAmpItemSetup {
 
         initialised = true;
 
+        // Item Recipes
         FnItemRecipes.setup(plugin);
         FnScrapRecipes.setup(plugin);
-        FNMaterialGenerators.setup(plugin);
-        FNPowerGenerators.setupPowerGens(plugin);
-        FNPowerGenerators.setupSolarGens(plugin);
+
+        // Items and Blocks
+        RegisterMaterialGenerators.setup(plugin);
+        RegisterMaterialGeneratorUpgrades.setup(plugin);
+        RegisterPowerGenerators.setup(plugin);
         RegisterMachines.setup(plugin);
         RegisterSticks.setup(plugin);
         RegisterGears.setup(plugin);
@@ -42,12 +46,14 @@ public final class FNAmpItemSetup {
         RegisterStaffs.setup(plugin);
         RegisterTools.setup(plugin);
 
+        // MultiBlocks
         new FnAssemblyStation().register(FNAmplifications.getInstance());
         new FnScrapRecycler().register(FNAmplifications.getInstance());
         new FnMysteryStickAltar().register(FNAmplifications.getInstance());
-        new FnGemAltar().register(FNAmplifications.getInstance());
         new FnMagicAltar().register(FNAmplifications.getInstance());
+        new FnGemAltar().register(FNAmplifications.getInstance());
         new FnGemUpgrader().register(FNAmplifications.getInstance());
+        new FnGemDowngrader().register(FNAmplifications.getInstance());
     }
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/items/FNAmpItems.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/items/FNAmpItems.java
@@ -71,6 +71,12 @@ public class FNAmpItems {
             new CustomItemStack(Material.EMERALD_BLOCK,
             "&eFN Material Generators"));
 
+    public static final SubItemGroup MATERIAL_GENERATORS_UPGRADES = new SubItemGroup(
+            new NamespacedKey(FNAmplifications.getInstance(), "MATERIAL_GENERATORS_UPGRADES"),
+            FN_MAIN_GROUP,
+            new CustomItemStack(Material.GOLD_BLOCK,
+                    "&eFN Material Generators Upgrades"));
+
     public static final SubItemGroup SOLAR_GENERATORS = new SubItemGroup(
             new NamespacedKey(FNAmplifications.getInstance(), "SOLAR_GENERATORS"),
             FN_MAIN_GROUP,
@@ -553,6 +559,30 @@ public class FNAmpItems {
             );
         }
     }
+
+    public static final SlimefunItemStack FN_MAT_GEN_UPGRADES_REPAIR_ITEM = new SlimefunItemStack(
+            "FN_MAT_GEN_UPGRADES_REPAIR_ITEM",
+            Material.BLACK_DYE,
+            "&fFN Mat Gen Repair Item",
+            "&6Repairs or add durability",
+            "",
+            "&e+20 durability",
+            "",
+            "&aRight click on a material generator",
+            "&d&oFN Material Generators Upgrades"
+    );
+
+    public static final SlimefunItemStack FN_MAT_GEN_UPGRADES_FAST_PRODUCE = new SlimefunItemStack(
+            "FN_MAT_GEN_UPGRADES_FAST_PRODUCE",
+            Material.YELLOW_DYE,
+            "&fFN Mat Gen Fast Produce",
+            "&6Faster production",
+            "",
+            "&e+1.75x Mat gen speed for 30 minutes",
+            "",
+            "&aRight click on a material generator",
+            "&d&oFN Material Generators Upgrades"
+    );
 
     public static final SlimefunItemStack FN_FAL_GENERATOR_TIER1 = new SlimefunItemStack(
             "FN_FAL_GENERATOR_TIER1",
@@ -1258,6 +1288,12 @@ public class FNAmpItems {
             "&dFN Gem Upgrader"
     );
 
+    public static final SlimefunItemStack FN_GEM_DOWNGRADER = new SlimefunItemStack(
+            "FN_GEM_DOWNGRADER",
+            Material.STONECUTTER,
+            "&dFN Gem Downgrader"
+    );
+
     public static final SlimefunItemStack FN_MAGIC_ALTAR = new SlimefunItemStack(
             "FN_MAGIC_ALTAR",
             PlayerHead.getItemStack(PlayerSkin.fromHashCode("e34930125767c2e34ac939ec94a2aa4e79c381ee336760695c6c874cf12")),
@@ -1829,10 +1865,10 @@ public class FNAmpItems {
             Material.EMERALD,
             "&cRetaliate Gem",
             "",
-            "&eAllows your weapons to return back to ",
-            "&eyou after throwing and hitting an object",
-            "&eor entity, weapon must have any of these",
-            "&egems bound to it before binding this gem:",
+            "&eAllows your weapons to return back to",
+            "&eyou after throwing it despite the distance.",
+            "&eThis gem requires throwable weapon gem",
+            "&efrom which one below:",
             "&e- Damnation Gem",
             "&e- Tri-Sword Gem",
             "&e- Axe Throwie Gem",
@@ -2412,6 +2448,16 @@ public class FNAmpItems {
             "&dClick this item to know how to upgrade",
             "&dgems and what recipe are needed in the",
             "&dFN Gem Upgrader Multiblock"
+    );
+
+    public static final SlimefunItemStack FN_GEM_DOWNGRADES_DISPLAY_ITEM = new SlimefunItemStack(
+            "FN_GEM_DOWNGRADE_DISPLAY_ITEM",
+            PlayerHead.getItemStack(PlayerSkin.fromHashCode("36161daa3589ec9c8187459ac36fd4dd2646c040678d3bfacb72a2210c6c801c")),
+            "&bGem Tier Downgrades",
+            "",
+            "&dClick this item to know how to downgrade",
+            "&dgems and what recipe are needed in the",
+            "&dFN Gem Downgrader Multiblock"
     );
 
     public static final SlimefunItemStack FN_GEM_FINE_JASPER_CRAFTING = new SlimefunItemStack(

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/CustomGeneratorMultiblock.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/CustomGeneratorMultiblock.java
@@ -15,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 
 public class CustomGeneratorMultiblock extends SimpleSlimefunItem<ItemUseHandler> implements NotPlaceable {
 
-    public CustomGeneratorMultiblock(ItemGroup itemGroup , SlimefunItemStack item) {
+    public CustomGeneratorMultiblock(ItemGroup itemGroup, SlimefunItemStack item) {
         super(itemGroup, item, RecipeType.MULTIBLOCK, new ItemStack[] {
                 null, null, null,
                 null, new ItemStack(Material.CHEST), null,

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGeneratorUpgrades.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGeneratorUpgrades.java
@@ -1,0 +1,35 @@
+package ne.fnfal113.fnamplifications.materialgenerators.implementations;
+
+import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
+import ne.fnfal113.fnamplifications.items.FNAmpItems;
+import ne.fnfal113.fnamplifications.materialgenerators.upgrades.FastProduce;
+import ne.fnfal113.fnamplifications.materialgenerators.upgrades.RepairItem;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class RegisterMaterialGeneratorUpgrades {
+
+    public static void setup(SlimefunAddon instance) {
+        new RepairItem(
+                FNAmpItems.MATERIAL_GENERATORS_UPGRADES,
+                FNAmpItems.FN_MAT_GEN_UPGRADES_REPAIR_ITEM,
+                RecipeType.COMPRESSOR,
+                new ItemStack[]{
+                        SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.SYNTHETIC_SAPPHIRE,
+                        SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.BLISTERING_INGOT, SlimefunItems.HARDENED_METAL_INGOT,
+                        SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.SYNTHETIC_SAPPHIRE}
+        ).register(instance);
+
+        new FastProduce(
+                FNAmpItems.MATERIAL_GENERATORS_UPGRADES,
+                FNAmpItems.FN_MAT_GEN_UPGRADES_FAST_PRODUCE,
+                RecipeType.COMPRESSOR,
+                new ItemStack[]{
+                        new ItemStack(Material.DIAMOND_SHOVEL), SlimefunItems.HARDENED_METAL_INGOT, new ItemStack(Material.DIAMOND_SHOVEL),
+                        SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.BLISTERING_INGOT, SlimefunItems.HARDENED_METAL_INGOT,
+                        new ItemStack(Material.DIAMOND_PICKAXE), SlimefunItems.HARDENED_METAL_INGOT, new ItemStack(Material.DIAMOND_PICKAXE)}
+        ).register(instance);
+    }
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGenerators.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGenerators.java
@@ -1,4 +1,4 @@
-package ne.fnfal113.fnamplifications.materialgenerators;
+package ne.fnfal113.fnamplifications.materialgenerators.implementations;
 
 import io.github.thebusybiscuit.slimefun4.api.MinecraftVersion;
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
@@ -15,12 +15,9 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 
 import ne.fnfal113.fnamplifications.config.ReturnConfValue;
 import ne.fnfal113.fnamplifications.items.FNAmpItems;
-import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomBrokenGenerator;
-import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomGeneratorMultiblock;
-import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
 import org.bukkit.inventory.meta.ItemMeta;
 
-public class FNMaterialGenerators {
+public class RegisterMaterialGenerators {
 
     private static final ReturnConfValue value = new ReturnConfValue();
 
@@ -79,7 +76,7 @@ public class FNMaterialGenerators {
                         SMG_ITEMSTACK_GRAVEL, FNAmpItems.FMG_GENERATOR_CLAY_BROKEN, SMG_ITEMSTACK_GRAVEL,
                         new ItemStack(Material.DIAMOND_PICKAXE), new ItemStack(Material.FURNACE), new ItemStack(Material.DIAMOND_PICKAXE)}, 32)
                 .setItem(Material.CLAY)
-                .getMaterialName("&3&lClay")
+                .setMaterialName("&3&lClay")
                 .register(instance);
 
         if(Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_16)) {
@@ -100,7 +97,7 @@ public class FNMaterialGenerators {
                             SMG_ITEMSTACK_NETHERRACK, FNAmpItems.FMG_GENERATOR_WARPED_BROKEN, SMG_ITEMSTACK_NETHERRACK,
                             SHOVEL.clone(), new ItemStack(Material.BLAST_FURNACE), SHOVEL.clone()}, 48)
                     .setItem(Material.WARPED_NYLIUM)
-                    .getMaterialName("&4&cWarped Nylium")
+                    .setMaterialName("&4&cWarped Nylium")
                     .register(instance);
         }
 
@@ -121,7 +118,7 @@ public class FNMaterialGenerators {
                         FNAmpItems.FMG_GENERATOR_CLAY, FNAmpItems.FMG_GENERATOR_TERRACOTTA_BROKEN, FNAmpItems.FMG_GENERATOR_CLAY,
                         SMG_ITEMSTACK_COBBLE, new ItemStack(Material.BLAST_FURNACE),SMG_ITEMSTACK_COBBLE}, 84)
                 .setItem(Material.TERRACOTTA)
-                .getMaterialName("&4&lTerracotta")
+                .setMaterialName("&4&lTerracotta")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -141,7 +138,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.BONE), FNAmpItems.FMG_GENERATOR_BONE_BROKEN, new ItemStack(Material.BONE),
                         SlimefunItems.PROGRAMMABLE_ANDROID, new ItemStack(Material.BLAST_FURNACE), SlimefunItems.PROGRAMMABLE_ANDROID}, 256)
                 .setItem(Material.BONE)
-                .getMaterialName("&f&lBone")
+                .setMaterialName("&f&lBone")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -161,7 +158,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.DIAMOND), FNAmpItems.FMG_GENERATOR_DIAMOND_BROKEN, new ItemStack(Material.DIAMOND),
                         SlimefunItems.PROGRAMMABLE_ANDROID, new ItemStack(Material.BLAST_FURNACE), SlimefunItems.PROGRAMMABLE_ANDROID}, 192)
                 .setItem(Material.DIAMOND)
-                .getMaterialName("&b&lDiamond")
+                .setMaterialName("&b&lDiamond")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -181,7 +178,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.EMERALD), FNAmpItems.FMG_GENERATOR_EMERALD_BROKEN, new ItemStack(Material.EMERALD),
                         SlimefunItems.PROGRAMMABLE_ANDROID, new ItemStack(Material.BLAST_FURNACE), SlimefunItems.PROGRAMMABLE_ANDROID}, 218)
                 .setItem(Material.EMERALD)
-                .getMaterialName("&a&lEmerald")
+                .setMaterialName("&a&lEmerald")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -201,7 +198,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.DIRT), FNAmpItems.FMG_GENERATOR_DIRT_BROKEN, new ItemStack(Material.DIRT),
                         SlimefunItems.MAGNESIUM_INGOT, new ItemStack(Material.BLAST_FURNACE), SlimefunItems.MAGNESIUM_INGOT}, 12)
                 .setItem(Material.DIRT)
-                .getMaterialName("&6&lDirt")
+                .setMaterialName("&6&lDirt")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -221,7 +218,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.HONEYCOMB), FNAmpItems.FMG_GENERATOR_HONEYCOMB_BROKEN, new ItemStack(Material.HONEYCOMB),
                         SlimefunItems.REINFORCED_ALLOY_INGOT, new ItemStack(Material.BLAST_FURNACE), SlimefunItems.REINFORCED_ALLOY_INGOT}, 48)
                 .setItem(Material.HONEYCOMB)
-                .getMaterialName("&6&lHoney Comb")
+                .setMaterialName("&6&lHoney Comb")
                 .register(instance);
 
         new CustomBrokenGenerator(FNAmpItems.MATERIAL_GENERATORS,
@@ -241,7 +238,7 @@ public class FNMaterialGenerators {
                         new ItemStack(Material.QUARTZ), FNAmpItems.FMG_GENERATOR_QUARTZ_BROKEN, new ItemStack(Material.QUARTZ),
                         SMG_ITEMSTACK_COBBLE, new ItemStack(Material.BLAST_FURNACE), SMG_ITEMSTACK_COBBLE}, 28)
                 .setItem(Material.QUARTZ)
-                .getMaterialName("&f&lQuartz")
+                .setMaterialName("&f&lQuartz")
                 .register(instance);
 
         if(Slimefun.getMinecraftVersion().isAtLeast(MinecraftVersion.MINECRAFT_1_17)){
@@ -267,7 +264,7 @@ public class FNMaterialGenerators {
                             new ItemStack(Material.AMETHYST_CLUSTER), FNAmpItems.FMG_GENERATOR_AMETHYST_BROKEN, new ItemStack(Material.AMETHYST_CLUSTER),
                             new ItemStack(Material.AMETHYST_BLOCK), new ItemStack(Material.BLAST_FURNACE), new ItemStack(Material.AMETHYST_BLOCK)}, 160)
                     .setItem(Material.AMETHYST_CLUSTER)
-                    .getMaterialName("&d&lAmethyst Cluster")
+                    .setMaterialName("&d&lAmethyst Cluster")
                     .register(instance);
         }
 

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/listener/UpgradesListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/listener/UpgradesListener.java
@@ -1,0 +1,58 @@
+package ne.fnfal113.fnamplifications.materialgenerators.listener;
+
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
+import ne.fnfal113.fnamplifications.materialgenerators.upgrades.abstracts.AbstractUpgrades;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.ItemStack;
+
+public class UpgradesListener implements Listener {
+
+    @EventHandler
+    public void onUpgradeClick(PlayerInteractEvent event) {
+        Player player = event.getPlayer();
+        ItemStack itemStack = player.getInventory().getItemInMainHand();
+        SlimefunItem sfItem = SlimefunItem.getByItem(itemStack);
+
+        if(event.getHand() == EquipmentSlot.OFF_HAND){
+            return;
+        }
+
+        if(event.getClickedBlock() == null || event.getClickedBlock().getType() == Material.AIR) {
+            return;
+        }
+
+        Block block = event.getClickedBlock();
+
+        if(itemStack.getType() == Material.AIR) {
+            return;
+        }
+
+        SlimefunItem sfBlock = BlockStorage.check(block);
+        if(!(sfBlock instanceof CustomMaterialGenerator)){
+            return;
+        }
+
+        CustomMaterialGenerator matGen = (CustomMaterialGenerator) sfBlock;
+
+        if(sfItem instanceof AbstractUpgrades) {
+            AbstractUpgrades upgrader = (AbstractUpgrades) sfItem;
+           if(upgrader.upgradeMaterialGenerator(block, player, matGen)) {
+               itemStack.setAmount(itemStack.getAmount() - 1);
+
+               player.sendMessage(upgrader.getUpgradeMessage());
+           }
+
+            event.setCancelled(true);
+        }
+
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/FastProduce.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/FastProduce.java
@@ -1,0 +1,44 @@
+package ne.fnfal113.fnamplifications.materialgenerators.upgrades;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
+import ne.fnfal113.fnamplifications.materialgenerators.upgrades.abstracts.AbstractUpgrades;
+import ne.fnfal113.fnamplifications.utils.Utils;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class FastProduce extends AbstractUpgrades {
+
+    public FastProduce(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, Utils.colorTranslator("&aMaterial Gen upgrade successful!"));
+    }
+
+
+    @Override
+    public boolean upgradeMaterialGenerator(Block sfBlock, Player player, CustomMaterialGenerator matGen) {
+        String blockInfo = BlockStorage.getLocationInfo(sfBlock.getLocation(), "fast_produce_multiplier");
+
+        if(blockInfo != null && Double.parseDouble(BlockStorage.getLocationInfo(sfBlock.getLocation(), "fast_produce_multiplier")) > 0){
+            player.sendMessage(Utils.colorTranslator("&cThis material generator still has fast produce upgrade!"));
+
+            return false;
+        }
+
+        // seconds * (mc ticks per second / sf ticker delay)
+        matGen.getGeneratorFastProduce().put(new BlockPosition(sfBlock.getLocation()),
+                new CustomMaterialGenerator.FastProduceCache(1.75, 0, (int) (1800 * (20.0 / Slimefun.getTickerTask().getTickRate()))));
+
+        BlockStorage.addBlockInfo(sfBlock.getLocation(), "fast_produce_multiplier", "1.75");
+        BlockStorage.addBlockInfo(sfBlock.getLocation(), "fast_produce_current_lifetime", "0");
+        BlockStorage.addBlockInfo(sfBlock.getLocation(), "fast_produce_max_lifetime", "1800");
+
+        return true;
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/RepairItem.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/RepairItem.java
@@ -1,0 +1,42 @@
+package ne.fnfal113.fnamplifications.materialgenerators.upgrades;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
+import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
+import ne.fnfal113.fnamplifications.materialgenerators.upgrades.abstracts.AbstractUpgrades;
+import ne.fnfal113.fnamplifications.utils.Utils;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class RepairItem extends AbstractUpgrades {
+
+    public RepairItem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(itemGroup, item, recipeType, recipe, Utils.colorTranslator("&aMaterial Gen repair successful!"));
+    }
+
+    @Override
+    public boolean upgradeMaterialGenerator(Block sfBlock, Player player, CustomMaterialGenerator matGen) {
+        int generatorCondition = Integer.parseInt(BlockStorage.getLocationInfo(sfBlock.getLocation(), "generator_status"));
+        int addCondition = 20;
+
+        if (generatorCondition == 100) {
+            player.sendMessage(Utils.colorTranslator("&6Cannot repair! material generator in good condition! "));
+            return false;
+        }
+
+        if (generatorCondition + addCondition > 100) {
+            BlockStorage.addBlockInfo(sfBlock, "generator_status", "100");
+            matGen.getGeneratorCondition().put(new BlockPosition(sfBlock.getLocation()), 100);
+        } else {
+            BlockStorage.addBlockInfo(sfBlock.getLocation(), "generator_status", String.valueOf(generatorCondition + addCondition));
+            matGen.getGeneratorCondition().put(new BlockPosition(sfBlock.getLocation()), generatorCondition + addCondition);
+        }
+
+        return true;
+    }
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/abstracts/AbstractUpgrades.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/abstracts/AbstractUpgrades.java
@@ -1,0 +1,34 @@
+package ne.fnfal113.fnamplifications.materialgenerators.upgrades.abstracts;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import lombok.Getter;
+import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+/**
+ * Superclass for item upgrade type for FN Material Generators
+ * @author fnfal113
+ */
+public abstract class AbstractUpgrades extends SlimefunItem {
+
+    @Getter
+    private final String upgradeMessage;
+
+    public AbstractUpgrades(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe, String upgradeMessage) {
+        super(itemGroup, item, recipeType, recipe);
+
+        this.upgradeMessage = upgradeMessage;
+    }
+
+    /**
+     *
+     * @return true if the upgrade was successful, false if not
+     */
+    public abstract boolean upgradeMaterialGenerator(Block sfBlock, Player player, CustomMaterialGenerator matGen);
+
+}

--- a/src/main/java/ne/fnfal113/fnamplifications/multiblocks/FnGemAltar.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/multiblocks/FnGemAltar.java
@@ -88,14 +88,12 @@ public class FnGemAltar extends MultiBlockMachine {
         Inventory fakeInv = createVirtualInventory(inv);
         Inventory outputInv = findOutputInventory(output, dispenser, inv, fakeInv);
 
+        craftItem(inv, recipe, b);
         if (outputInv != null) {
-            craftItem(inv, recipe, b);
-
             outputInv.addItem(output);
         } else {
-            craftItem(inv, recipe, b);
-
             dispenser.getWorld().dropItem(b.getLocation(), output);
+
             Slimefun.getLocalization().sendMessage(p, "machines.full-inventory", true);
             p.sendMessage(Utils.colorTranslator("&dCrafted item has been dropped instead"));
         }

--- a/src/main/java/ne/fnfal113/fnamplifications/multiblocks/FnGemDowngrader.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/multiblocks/FnGemDowngrader.java
@@ -31,25 +31,26 @@ import org.bukkit.persistence.PersistentDataType;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
+import java.util.concurrent.ThreadLocalRandom;
 
-public class FnGemUpgrader extends MultiBlockMachine {
+public class FnGemDowngrader extends MultiBlockMachine {
 
     private final int[] slot = {0, 2, 4, 6, 8};
     private final int[] blankSlots = {1, 3, 5, 7};
 
     public static final RecipeType RECIPE_TYPE = new RecipeType(
-            new NamespacedKey(FNAmplifications.getInstance(), "fn_gem_upgrader"),
-            FNAmpItems.FN_GEM_UPGRADER,
+            new NamespacedKey(FNAmplifications.getInstance(), "fn_gem_downgrader"),
+            FNAmpItems.FN_GEM_DOWNGRADER,
             "",
-            "&fThis is where you upgrade those shiny gems!"
+            "&fThis is where you downgrade those shiny gems!"
     );
 
 
-    public FnGemUpgrader() {
-        super(FNAmpItems.MULTIBLOCK, FNAmpItems.FN_GEM_UPGRADER, new ItemStack[] {
+    public FnGemDowngrader() {
+        super(FNAmpItems.MULTIBLOCK, FNAmpItems.FN_GEM_DOWNGRADER, new ItemStack[] {
                 null , null , null,
                 null, new ItemStack(Material.ACACIA_FENCE), null,
-                new ItemStack(Material.GRINDSTONE), new ItemStack(Material.DISPENSER), new ItemStack(Material.GRINDSTONE)
+                new ItemStack(Material.GRINDSTONE), new ItemStack(Material.DISPENSER), new ItemStack(Material.STONECUTTER)
         }, BlockFace.SELF);
     }
 
@@ -62,10 +63,10 @@ public class FnGemUpgrader extends MultiBlockMachine {
             Dispenser disp = (Dispenser) state;
             Inventory inv = disp.getInventory();
 
-            if(inv.getContents()[0] != null && inv.getContents()[4] != null) {
-                if (canCraft(inv, inv.getContents()[0].clone(), p)) {
-                    String id = Objects.requireNonNull(SlimefunItem.getByItem(inv.getContents()[0])).getId();
-                    ItemStack output = Objects.requireNonNull(inv.getItem(0)).clone();
+            if(inv.getContents()[4] != null && inv.getContents()[0] != null) {
+                if (canCraft(inv, inv.getContents()[4].clone(), p)) {
+                    String id = Objects.requireNonNull(SlimefunItem.getByItem(inv.getContents()[4])).getId();
+                    ItemStack output = Objects.requireNonNull(inv.getItem(4)).clone();
 
                     output.setAmount(1);
                     craft(dispBlock, p, b, inv, output, id);
@@ -88,31 +89,27 @@ public class FnGemUpgrader extends MultiBlockMachine {
             }
         }
 
-        if(!SlimefunUtils.isItemSimilar(inv.getContents()[4], FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING, true, false)){
-            return false;
-        }
-
         for (int i : slot) {
             if(i == 4){
                 continue;
             }
 
-            if(SlimefunItem.getByItem(gem) instanceof GemUpgrade) {
-                ItemStack itemStack = inv.getContents()[i];
-                SlimefunItem sfItem = SlimefunItem.getByItem(itemStack);
-
-                if (sfItem instanceof GemUpgrade && SlimefunUtils.isItemSimilar(itemStack, gem, true, false)) {
-                    if(((GemUpgrade) sfItem).getTier(itemStack, sfItem.getId()) == 1){
-                        p.playSound(p.getLocation(), Sound.ENTITY_VILLAGER_NO, 1.0F, 1.0F);
-                        p.sendMessage(Utils.colorTranslator("&cMax tier reached! Gem cannot be upgraded anymore!"));
-                        return false;
-                    }
-                } else {
-                    return false;
-                }
-            } else {
+            if(!SlimefunUtils.isItemSimilar(inv.getContents()[i], FNAmpItems.FN_GEM_FINE_JASPER_CRAFTING, true, false)) {
                 return false;
             }
+        }
+
+        SlimefunItem sfItem = SlimefunItem.getByItem(gem);
+
+        if(!(sfItem instanceof GemUpgrade)){
+            return false;
+        }
+
+        if(((GemUpgrade) sfItem).getTier(gem, sfItem.getId()) == 4){
+            p.playSound(p.getLocation(), Sound.ENTITY_VILLAGER_NO, 1.0F, 1.0F);
+            p.sendMessage(Utils.colorTranslator("&cTier 1 gem cannot be downgraded!"));
+
+            return false;
         }
 
         return true;
@@ -124,19 +121,21 @@ public class FnGemUpgrader extends MultiBlockMachine {
         Inventory outputInv = findOutputInventory(finalOutput, dispenser, inv, fakeInv);
 
         craftItem(inv, b);
+        finalOutput.setAmount(ThreadLocalRandom.current().nextInt() < 50 ? 2 : 3);
         if (outputInv != null) {
 
             outputInv.addItem(finalOutput);
         } else {
             dispenser.getWorld().dropItem(b.getLocation(), finalOutput);
+
             Slimefun.getLocalization().sendMessage(p, "machines.full-inventory", true);
             p.sendMessage(Utils.colorTranslator("&dCrafted item has been dropped instead"));
         }
 
         if(output.getItemMeta().hasDisplayName()){
-            p.sendMessage(Utils.colorTranslator("&dSuccessfully upgraded to " + output.getItemMeta().getDisplayName() + "!"));
+            p.sendMessage(Utils.colorTranslator("&dSuccessfully downgraded to " + output.getItemMeta().getDisplayName() + "!"));
         } else{
-            p.sendMessage(Utils.colorTranslator("&dSuccessfully upgraded the gem!"));
+            p.sendMessage(Utils.colorTranslator("&dSuccessfully downgraded the gem!"));
         }
     }
 
@@ -144,31 +143,29 @@ public class FnGemUpgrader extends MultiBlockMachine {
         for (int i : slot) {
             ItemStack item = inv.getContents()[i];
 
-            if(item != null && item.getType() != Material.AIR) {
-                ItemUtils.consumeItem(item, 1, true);
-            }
+            ItemUtils.consumeItem(item, 1, true);
         }
 
         Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
             b.getWorld().playEffect(b.getLocation().add(0.5, 0.7, 0.5), Effect.SMOKE, 1);
-            b.getWorld().spawnParticle(Particle.SMOKE_NORMAL, b.getLocation().add(0.3, 1.7, 0.45), 2, 0.1, 0.1, 0.1, 0.1);
-            b.getWorld().playSound(b.getLocation(), Sound.BLOCK_ANVIL_PLACE, 1, 1);
+            b.getWorld().spawnParticle(Particle.FLASH, b.getLocation().add(0.3, 1.7, 0.45), 2, 0.1, 0.1, 0.1, 0.1);
+            b.getWorld().playSound(b.getLocation(), Sound.UI_STONECUTTER_SELECT_RECIPE, 1, 1);
 
             Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
                 b.getWorld().spawnParticle(Particle.FLAME, b.getLocation().add(0.4, 0.45, 0.5), 2, 0.1, 0.1, 0.1, 0.1);
-                b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.4, 0.5, 0.5), 2, 0.1, 0.1, 0.1, 0.1);
-                b.getWorld().playSound(b.getLocation(), Sound.ITEM_FIRECHARGE_USE, 1, 1);
+                b.getWorld().spawnParticle(Particle.SMOKE_LARGE, b.getLocation().add(0.4, 0.5, 0.5), 2, 0.1, 0.1, 0.1, 0.1);
+                b.getWorld().playSound(b.getLocation(), Sound.BLOCK_GRINDSTONE_USE, 1, 1);
 
                 Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
                     b.getWorld().playEffect(b.getLocation().add(0.35, 0.75, 0.35), Effect.MOBSPAWNER_FLAMES, 1);
                     b.getWorld().spawnParticle(Particle.SMOKE_LARGE, b.getLocation().add(0.2, 1.7, 0.2), 2, 0.1, 0.1, 0.1, 0.1);
-                    b.getWorld().playSound(b.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1);
+                    b.getWorld().playSound(b.getLocation(), Sound.UI_STONECUTTER_TAKE_RESULT, 1, 1);
 
                     Bukkit.getScheduler().runTaskLater(FNAmplifications.getInstance(), () -> {
                         b.getWorld().playEffect(b.getLocation().add(0.5, 0.7, 0.5), Effect.SMOKE, 1);
                         b.getWorld().spawnParticle(Particle.FLASH, b.getLocation().add(0.35, 0.4, 0.4), 2, 0.1, 0.1, 0.1, 0.1);
                         b.getWorld().spawnParticle(Particle.CLOUD, b.getLocation().add(0.35, 0.5, 0.4), 2, 0.1, 0.1, 0.1, 0.1);
-                        b.getWorld().playSound(b.getLocation(), Sound.BLOCK_ANVIL_USE, 1, 1);
+                        b.getWorld().playSound(b.getLocation(), Sound.ENTITY_GENERIC_EXPLODE, 1, 1);
 
                     }, 30);
                 }, 30);
@@ -182,11 +179,11 @@ public class FnGemUpgrader extends MultiBlockMachine {
         NamespacedKey key = Keys.createKey(id + "_gem_tier");
         int tier = pdc.getOrDefault(key, PersistentDataType.INTEGER, 4);
 
-        pdc.set(key, PersistentDataType.INTEGER, tier - 1);
-        if(tier == 4) {
-            meta.setDisplayName(meta.getDisplayName() + " " + getTierRomanNumeral(tier - 1));
+        pdc.set(key, PersistentDataType.INTEGER, tier + 1);
+        if(tier == 3){
+            meta.setDisplayName(meta.getDisplayName().replace(" " + getTierRomanNumeral(tier), getTierRomanNumeral(tier + 1)));
         } else {
-            meta.setDisplayName(meta.getDisplayName().replace(getTierRomanNumeral(tier), getTierRomanNumeral(tier - 1)));
+            meta.setDisplayName(meta.getDisplayName().replace(getTierRomanNumeral(tier), getTierRomanNumeral(tier + 1)));
         }
         output.setItemMeta(meta);
 
@@ -198,9 +195,11 @@ public class FnGemUpgrader extends MultiBlockMachine {
             return "II";
         } else if(tier == 2){
             return "III";
+        } else if (tier == 1){
+            return "IV";
         }
 
-        return "IV";
+        return "";
     }
 
     protected @Nonnull
@@ -220,6 +219,4 @@ public class FnGemUpgrader extends MultiBlockMachine {
 
         return fakeInv;
     }
-
-
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/powergenerators/implementation/RegisterPowerGenerators.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/powergenerators/implementation/RegisterPowerGenerators.java
@@ -1,4 +1,4 @@
-package ne.fnfal113.fnamplifications.powergenerators;
+package ne.fnfal113.fnamplifications.powergenerators.implementation;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
@@ -15,7 +15,7 @@ import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 
 import ne.fnfal113.fnamplifications.items.FNAmpItems;
 
-public class FNPowerGenerators {
+public class RegisterPowerGenerators {
 
     private static final ReturnConfValue value = new ReturnConfValue();
 
@@ -49,7 +49,7 @@ public class FNPowerGenerators {
         }
     }
 
-    public static void setupPowerGens(SlimefunAddon instance) {
+    public static void setup(SlimefunAddon instance) {
         new CustomPowerGen(FNAmpItems.POWER_GENERATORS, FNAmpItems.FN_XPANSION_POWER_R1, FnAssemblyStation.RECIPE_TYPE, new ItemStack[]{
                 FNAmpItems.POWER_COMPONENT, new CustomItemStack(LITEX_ITEMSTACK_TIN, 3), FNAmpItems.POWER_COMPONENT,
                 FNAmpItems.BASIC_MACHINE_BLOCK, SlimefunItems.SOLAR_GENERATOR_4, FNAmpItems.BASIC_MACHINE_BLOCK,
@@ -121,9 +121,8 @@ public class FNPowerGenerators {
                 SlimefunItems.ENERGIZED_CAPACITOR, new CustomItemStack(LITEX_ITEMSTACK_REINFORCED, 20), SlimefunItems.ENERGIZED_CAPACITOR,
                 FNAmpItems.REINFORCED_CASING, FNAmpItems.FN_XPANSION_POWER_R5, SlimefunItems.BOOSTED_URANIUM
         }, 17421, 10128, 1780, 2000000).register(instance);
-    }
 
-    public static void setupSolarGens(SlimefunAddon instance){
+        // Solar Generators
         new CustomSolarGen(FNAmpItems.SOLAR_GENERATORS, FNAmpItems.FN_FAL_GENERATOR_TIER1, RecipeType.ENHANCED_CRAFTING_TABLE, new ItemStack[]{
                 SlimefunItems.SOLAR_GENERATOR_2, SlimefunItems.SOLAR_GENERATOR, SlimefunItems.SOLAR_GENERATOR_2,
                 SlimefunItems.BIG_CAPACITOR, SlimefunItems.POWER_CRYSTAL, SlimefunItems.BIG_CAPACITOR,

--- a/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
@@ -45,12 +45,19 @@ public class PlayerJoinLister implements Listener {
                 Utils.colorTranslator("&e&lFN &c&lAmpli&b&lfications &r&e" + FNAmplifications.getInstance().getDescription().getVersion()),
                 Utils.colorTranslator("&fChangelog"),
                 "",
-                Utils.colorTranslator("  &d- 1.15 minecraft version support has been removed"),
-                Utils.colorTranslator("  &d- Code cleanup for FN Gems"),
+                Utils.colorTranslator("  &d- Retaliate gem now returns weapon to player without dropping it on the ground"),
+                Utils.colorTranslator("  &d- Fixed block rotator able to rotate wall attachable items that " +
+                        "shouldn't be rotated if the next block being attached to is not solid"),
+                Utils.colorTranslator("  &d- Downgrade gems through FN Gem Downgrader multiblock and" +
+                        "yield back 2 or 3 previous tier gem"),
+                Utils.colorTranslator("  &d- Fixed mat gen not resetting progress on break at the block placed location"),
+                Utils.colorTranslator("  &d- Introducing material generator upgrades:"),
+                Utils.colorTranslator("  &f  + Repair item - repair your mat gens"),
+                Utils.colorTranslator("  &f  + Fast Produce - +1.75x speed to your mat gens for 30 minutes"),
                 Utils.colorTranslator(""),
                 Utils.colorTranslator("&eChangelog notification can be disabled in config.yml"),
                 Utils.colorTranslator(""),
-                Utils.colorTranslator("&eYou may visit this website for the item wiki:"),
+                Utils.colorTranslator("&eYou may visit this website for the fn items wiki:"),
                 Utils.colorTranslator("&e&nhttps://fnfal113.tech/fnAmpItems"),
                 "||---------------------------------------------------||"
         );


### PR DESCRIPTION
## Changes
- Retaliate gem now returns the weapon instead of dropping on the ground when it reaches the max distance
- Fixed block rotator directional rotations for wall items, prevent rotating if next attach block is air
- Downgradeable gems through downgrader multiblock
- Fixed mat gen not resetting progress on break at the block placed location
- Mat gen upgrades (repair item and fast produce)
- Code chores (renamed and moved classes to appropriate packages)

## Related Issues
- TBD

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
