### PR TITLE
Mat gen and upgrades changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>Unoffical-3.3.2</version>
+    <version>Unoffical-3.3.4</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/CustomMaterialGenerator.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/CustomMaterialGenerator.java
@@ -230,7 +230,7 @@ public class CustomMaterialGenerator extends SlimefunItem implements InventoryBl
                         progress = 0;
                         // if generator condition is greater than 0, check
                         if(getGeneratorCondition().get(pos) != 0) {
-                            if (ThreadLocalRandom.current().nextInt(100) < 30) {
+                            if (ThreadLocalRandom.current().nextInt(100) < 25) {
                                 BlockStorage.addBlockInfo(b.getLocation(), "generator_status", String.valueOf(generatorCondition - 1));
                                 getGeneratorCondition().put(pos, generatorCondition - 1);
                             }

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGeneratorUpgrades.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/implementations/RegisterMaterialGeneratorUpgrades.java
@@ -1,11 +1,11 @@
 package ne.fnfal113.fnamplifications.materialgenerators.implementations;
 
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
-import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import ne.fnfal113.fnamplifications.items.FNAmpItems;
 import ne.fnfal113.fnamplifications.materialgenerators.upgrades.FastProduce;
 import ne.fnfal113.fnamplifications.materialgenerators.upgrades.RepairItem;
+import ne.fnfal113.fnamplifications.multiblocks.FnAssemblyStation;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -15,21 +15,21 @@ public class RegisterMaterialGeneratorUpgrades {
         new RepairItem(
                 FNAmpItems.MATERIAL_GENERATORS_UPGRADES,
                 FNAmpItems.FN_MAT_GEN_UPGRADES_REPAIR_ITEM,
-                RecipeType.COMPRESSOR,
+                FnAssemblyStation.RECIPE_TYPE,
                 new ItemStack[]{
-                        SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.SYNTHETIC_SAPPHIRE,
-                        SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.BLISTERING_INGOT, SlimefunItems.HARDENED_METAL_INGOT,
-                        SlimefunItems.SYNTHETIC_SAPPHIRE, SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.SYNTHETIC_SAPPHIRE}
+                        SlimefunItems.BRONZE_INGOT, null, SlimefunItems.ALUMINUM_INGOT,
+                        null, new ItemStack(Material.DIAMOND_PICKAXE), null,
+                        SlimefunItems.STEEL_INGOT, null, SlimefunItems.BRASS_INGOT}
         ).register(instance);
 
         new FastProduce(
                 FNAmpItems.MATERIAL_GENERATORS_UPGRADES,
                 FNAmpItems.FN_MAT_GEN_UPGRADES_FAST_PRODUCE,
-                RecipeType.COMPRESSOR,
+                FnAssemblyStation.RECIPE_TYPE,
                 new ItemStack[]{
-                        new ItemStack(Material.DIAMOND_SHOVEL), SlimefunItems.HARDENED_METAL_INGOT, new ItemStack(Material.DIAMOND_SHOVEL),
-                        SlimefunItems.HARDENED_METAL_INGOT, SlimefunItems.BLISTERING_INGOT, SlimefunItems.HARDENED_METAL_INGOT,
-                        new ItemStack(Material.DIAMOND_PICKAXE), SlimefunItems.HARDENED_METAL_INGOT, new ItemStack(Material.DIAMOND_PICKAXE)}
+                        new ItemStack(Material.DIAMOND_SHOVEL), SlimefunItems.DURALUMIN_INGOT, new ItemStack(Material.DIAMOND_SHOVEL),
+                        SlimefunItems.HARDENED_METAL_INGOT, null, SlimefunItems.HARDENED_METAL_INGOT,
+                        new ItemStack(Material.DIAMOND_PICKAXE), SlimefunItems.BILLON_INGOT, new ItemStack(Material.DIAMOND_PICKAXE)}
         ).register(instance);
     }
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
@@ -26,7 +26,8 @@ public class PlayerJoinLister implements Listener {
             return;
         }
 
-        if(players.contains(player.getUniqueId())){ // only send once when player joins fresh after server restart
+        // only send once when player joins fresh after server restart
+        if(players.contains(player.getUniqueId())){
            return;
         }
 
@@ -45,15 +46,9 @@ public class PlayerJoinLister implements Listener {
                 Utils.colorTranslator("&e&lFN &c&lAmpli&b&lfications &r&e" + FNAmplifications.getInstance().getDescription().getVersion()),
                 Utils.colorTranslator("&fChangelog"),
                 "",
-                Utils.colorTranslator("  &d- Retaliate gem now returns weapon to player without dropping it on the ground"),
-                Utils.colorTranslator("  &d- Fixed block rotator able to rotate wall attachable items that " +
-                        "shouldn't be rotated if the next block being attached to is not solid"),
-                Utils.colorTranslator("  &d- Downgrade gems through FN Gem Downgrader multiblock and" +
-                        "yield back 2 or 3 previous tier gem"),
-                Utils.colorTranslator("  &d- Fixed mat gen not resetting progress on break at the block placed location"),
-                Utils.colorTranslator("  &d- Introducing material generator upgrades:"),
-                Utils.colorTranslator("  &f  + Repair item - repair your mat gens"),
-                Utils.colorTranslator("  &f  + Fast Produce - +1.75x speed to your mat gens for 30 minutes"),
+                Utils.colorTranslator("  &d- Changed material gen upgrades multiblock to FN Assembly Station and " +
+                        "rebalanced the recipes"),
+                Utils.colorTranslator("  &d- Mat gen chance for 1 durability wear decreased from 30% to 25%"),
                 Utils.colorTranslator(""),
                 Utils.colorTranslator("&eChangelog notification can be disabled in config.yml"),
                 Utils.colorTranslator(""),


### PR DESCRIPTION
## Changes
- Changed material gen upgrades multiblock to FN Assembly Station and rebalanced the recipes
- Mat gen chance for 1 durability wear decreased from 30% to 25%

## Related Issues
- To be determined

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
