### PR TITLE
Fixed hasty gem upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>Unoffical-3.3.4</version>
+    <version>Unoffical-3.3.5</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/HastyGem.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/HastyGem.java
@@ -6,6 +6,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.utils.tags.SlimefunTag;
 import ne.fnfal113.fnamplifications.gems.abstracts.AbstractGem;
+import ne.fnfal113.fnamplifications.gems.handlers.GemUpgrade;
 import ne.fnfal113.fnamplifications.utils.WeaponArmorEnum;
 import ne.fnfal113.fnamplifications.gems.handlers.OnBlockBreakHandler;
 import ne.fnfal113.fnamplifications.utils.Utils;
@@ -20,7 +21,7 @@ import org.bukkit.potion.PotionEffectType;
 
 import java.util.concurrent.ThreadLocalRandom;
 
-public class HastyGem extends AbstractGem implements OnBlockBreakHandler {
+public class HastyGem extends AbstractGem implements OnBlockBreakHandler, GemUpgrade {
 
     public HastyGem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe, 16);
@@ -30,21 +31,25 @@ public class HastyGem extends AbstractGem implements OnBlockBreakHandler {
     public void onDrag(Player player, SlimefunItem gem, ItemStack gemItem, ItemStack currentItem){
         if (WeaponArmorEnum.AXES.isTagged(currentItem.getType()) || WeaponArmorEnum.SHOVELS.isTagged(currentItem.getType())
                 || WeaponArmorEnum.PICKAXE.isTagged(currentItem.getType())) {
-            bindGem(gem, currentItem, player, false);
+            if(isUpgradeGem(gemItem, this.getId())) {
+                upgradeGem(gem, currentItem, gemItem, player, this.getId());
+            } else {
+                bindGem(gem, currentItem, player, false);
+            }
         } else {
             player.sendMessage(Utils.colorTranslator("&eInvalid item to socket! Gem works on shovels, pickaxes and axes only"));
         }
     }
 
     @Override
-    public void onBlockBreak(BlockBreakEvent event, Player player){
+    public void onBlockBreak(BlockBreakEvent event, Player player, ItemStack itemStack){
         if(event.isCancelled()){
             return;
         }
         Block block = event.getBlock();
 
         if(SlimefunTag.ORES.isTagged(block.getType()) || SlimefunTag.STONE_VARIANTS.isTagged(block.getType())) {
-            if (ThreadLocalRandom.current().nextInt(100) < getChance()) {
+            if (ThreadLocalRandom.current().nextInt(100) < (getChance() / getTier(itemStack, this.getId()))) {
                 PotionEffect potionEffect = new PotionEffect(PotionEffectType.FAST_DIGGING, 80, 2, true, false, false);
                 player.addPotionEffect(potionEffect);
                 player.spigot().sendMessage(ChatMessageType.ACTION_BAR,

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/TelepathyGem.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/TelepathyGem.java
@@ -34,7 +34,7 @@ public class TelepathyGem extends AbstractGem implements OnBlockBreakHandler {
     }
 
     @Override
-    public void onBlockBreak(BlockBreakEvent event, Player player){
+    public void onBlockBreak(BlockBreakEvent event, Player player, ItemStack itemStack){
         if (event.isCancelled()){
             return;
         }

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/handlers/OnBlockBreakHandler.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/handlers/OnBlockBreakHandler.java
@@ -2,6 +2,7 @@ package ne.fnfal113.fnamplifications.gems.handlers;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
 
 public interface OnBlockBreakHandler extends GemHandler{
 
@@ -9,8 +10,8 @@ public interface OnBlockBreakHandler extends GemHandler{
      *
      * @param event the block break event and listens if a block is broken
      * @param player the player who broke the block
+     * @param itemStack the item where the gem is bound at
      */
-    void onBlockBreak(BlockBreakEvent event, Player player);
-
+    void onBlockBreak(BlockBreakEvent event, Player player, ItemStack itemStack);
 
 }

--- a/src/main/java/ne/fnfal113/fnamplifications/gems/listener/GemListener.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/gems/listener/GemListener.java
@@ -233,7 +233,7 @@ public class GemListener implements Listener {
         ItemStack itemStack = player.getInventory().getItemInMainHand();
         PersistentDataContainer pdc = getPersistentDataContainer(itemStack);
 
-        callGemHandler(OnBlockBreakHandler.class, handler -> handler.onBlockBreak(event, player), itemStack, pdc, player);
+        callGemHandler(OnBlockBreakHandler.class, handler -> handler.onBlockBreak(event, player, itemStack), itemStack, pdc, player);
     }
 
     @EventHandler

--- a/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/utils/PlayerJoinLister.java
@@ -46,10 +46,9 @@ public class PlayerJoinLister implements Listener {
                 Utils.colorTranslator("&e&lFN &c&lAmpli&b&lfications &r&e" + FNAmplifications.getInstance().getDescription().getVersion()),
                 Utils.colorTranslator("&fChangelog"),
                 "",
-                Utils.colorTranslator("  &d- Changed material gen upgrades multiblock to FN Assembly Station and " +
-                        "rebalanced the recipes"),
-                Utils.colorTranslator("  &d- Mat gen chance for 1 durability wear decreased from 30% to 25%"),
+                Utils.colorTranslator("  &d- Fixed Hasty Gem not being upgradeable"),
                 Utils.colorTranslator(""),
+                Utils.colorTranslator("&fHappy Holidays Gamer! Hope you have a bright day ahead!"),
                 Utils.colorTranslator("&eChangelog notification can be disabled in config.yml"),
                 Utils.colorTranslator(""),
                 Utils.colorTranslator("&eYou may visit this website for the fn items wiki:"),


### PR DESCRIPTION
## Changes
- Fixed hasty gem upgrade, forgot to implement ```GemUpgrade``` interface

## Related Issues
<!-- Please tag any Issues related to your Pull Request -->
<!-- Syntax: "Resolves #000" -->

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
