### PR TITLE
add mat gen config options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>Unoffical-4.0.0</version>
+    <version>Unoffical-4.0.1</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>

--- a/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/RepairItem.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/materialgenerators/upgrades/RepairItem.java
@@ -5,6 +5,7 @@ import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItemStack;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.blocks.BlockPosition;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
+import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.materialgenerators.implementations.CustomMaterialGenerator;
 import ne.fnfal113.fnamplifications.materialgenerators.upgrades.abstracts.AbstractUpgrades;
 import ne.fnfal113.fnamplifications.utils.Utils;
@@ -14,17 +15,23 @@ import org.bukkit.inventory.ItemStack;
 
 public class RepairItem extends AbstractUpgrades {
 
+    private final boolean breakOverTime = FNAmplifications.getInstance().getConfig().getBoolean("Enable-Mat-Gen-Break-Over-Time", true);
+
     public RepairItem(ItemGroup itemGroup, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(itemGroup, item, recipeType, recipe, Utils.colorTranslator("&aMaterial Gen repair successful!"));
     }
 
     @Override
     public boolean upgradeMaterialGenerator(Block sfBlock, Player player, CustomMaterialGenerator matGen) {
+        if(!breakOverTime) {
+            return false;
+        }
+
         int generatorCondition = Integer.parseInt(BlockStorage.getLocationInfo(sfBlock.getLocation(), "generator_status"));
         int addCondition = 20;
 
         if (generatorCondition == 100) {
-            player.sendMessage(Utils.colorTranslator("&6Cannot repair! material generator in good condition! "));
+            player.sendMessage(Utils.colorTranslator("&6Cannot repair! material generator in good condition!"));
             return false;
         }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -30,3 +30,10 @@ Enable-PowerXpansion: true
 Enable-Staffs: true
 Enable-Quivers: true
 Enable-Misc: true
+
+# Allow material generators to break over time
+Enable-Mat-Gen-Break-Over-Time: true
+# Allow material generators to drop broken variant only on block break
+Enable-Mat-Gen-Broken-Drop: true
+
+


### PR DESCRIPTION
## Changes
- Add ```Enable-Mat-Gen-Break-Over-Time``` and ```Enable-Mat-Gen-Broken-Drop``` in config.yml

## Related Issues
- To be determined

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [x] I followed the existing code standards and didn't mess up the formatting.
- [x] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
