### PR TITLE
jukebox missing discs and duration tick rate fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,12 +6,12 @@
 
     <groupId>ne.fnfal113</groupId>
     <artifactId>FNAmplifications</artifactId>
-    <version>Unoffical-4.1.7</version>
+    <version>Unoffical-4.1.8</version>
     <packaging>jar</packaging>
 
     <name>FNAmplifications</name>
 
-    <description>Adds different kind of items in-game from machines, utilities to pvp related items! Take part on exploring FN's offering!</description>
+    <description>Adds different kind of in-game items from machines, utilities to pvp related items! Take part on exploring FN's offering!</description>
     
     <properties>
         <java.version>1.8</java.version>

--- a/src/main/java/ne/fnfal113/fnamplifications/machines/ElectricJukebox.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/machines/ElectricJukebox.java
@@ -20,7 +20,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenuPreset;
 import me.mrCookieSlime.Slimefun.api.item_transport.ItemTransportFlow;
-import ne.fnfal113.fnamplifications.FNAmplifications;
 import ne.fnfal113.fnamplifications.machines.abstracts.AbstractJukeBox;
 import ne.fnfal113.fnamplifications.machines.implementation.DiscDurationsEnum;
 import ne.fnfal113.fnamplifications.utils.Utils;
@@ -303,17 +302,22 @@ public class ElectricJukebox extends AbstractJukeBox {
                     menu.replaceExistingItem(48, OPERATING);
 
                     if(jukebox.getPlaying() != Material.AIR) {
-                        menu.replaceExistingItem(49, new CustomItemStack(Material.PINK_STAINED_GLASS_PANE,
-                            "&d&lPlaying: " + jukebox.getPlaying().toString().replace("_", " "),
-                            "&eDuration : " + 
-                            durationMap.get(b.getLocation()) + "/" + 
-                            (DiscDurationsEnum.valueOf(jukebox.getPlaying().toString().toUpperCase()).getDurationInSec() * 2)));
+                        menu.replaceExistingItem(
+                            49, 
+                            new CustomItemStack(
+                                Material.PINK_STAINED_GLASS_PANE,
+                                "&d&lPlaying: " + jukebox.getPlaying().toString().replace("_", " "),
+                                "&eDuration : " + 
+                                durationMap.get(b.getLocation()) + "/" + 
+                                (DiscDurationsEnum.valueOf(jukebox.getPlaying().toString().toUpperCase()).getDuration())
+                            )
+                        );
                     }
                 } 
 
                 // when disc duration has elapsed, check next slot if there is a disc else stop the jukebox or go back to default slot when upper bound is reached
                 if(durationMap.containsKey(b.getLocation())) {
-                    if (durationMap.get(b.getLocation()) >= (DiscDurationsEnum.valueOf(jukebox.getPlaying().toString().toUpperCase()).getDurationInSec() * 2)) {
+                    if (durationMap.get(b.getLocation()) >= DiscDurationsEnum.valueOf(jukebox.getPlaying().toString().toUpperCase()).getDuration()) {
                         goToNextSlot(menu, null);
                         
                         currentTime = 0;

--- a/src/main/java/ne/fnfal113/fnamplifications/machines/implementation/DiscDurationsEnum.java
+++ b/src/main/java/ne/fnfal113/fnamplifications/machines/implementation/DiscDurationsEnum.java
@@ -1,5 +1,7 @@
 package ne.fnfal113.fnamplifications.machines.implementation;
 
+import io.github.thebusybiscuit.slimefun4.implementation.Slimefun;
+
 public enum DiscDurationsEnum {
 
     MUSIC_DISC_13(180),
@@ -16,16 +18,18 @@ public enum DiscDurationsEnum {
     MUSIC_DISC_WAIT(235),
     MUSIC_DISC_OTHERSIDE(180),
     MUSIC_DISC_PIGSTEP(148),
+    MUSIC_DISC_5(178),
+    MUSIC_DISC_RELIC(216),
     ;
 
-    private final int durationInSec;
+    private final int duration;
 
-    DiscDurationsEnum(int durationInSec) {
-        this.durationInSec = durationInSec;
+    DiscDurationsEnum(int durationInSeconds) {
+        this.duration = durationInSeconds * (int) 20.0 / Slimefun.getTickerTask().getTickRate();
     }
 
-    public int getDurationInSec(){
-        return durationInSec;
+    public int getDuration() {
+        return duration;
     }
 
 }


### PR DESCRIPTION
## Changes
- resolves #118
- slimefun tickrate is now utilized to adjust initial duration in seconds.

## Related Issues
- TBD

## Checklist
<!-- Here is a little checklist you should follow. -->
<!-- You can click those check boxes after you posted your issue. -->
- [x] I have fully tested the proposed changes and promise that they will not break world generation, mob spawning, and the like.
- [ ] I followed the existing code standards and didn't mess up the formatting.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] I have added `Nonnull` and `Nullable` annotations to my methods to indicate their behaviour for null values
